### PR TITLE
[Feat] #37 - Bottom Button View 컴포넌트화

### DIFF
--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		864FA9032C3D1F7B0051EA36 /* MypageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9022C3D1F7B0051EA36 /* MypageViewController.swift */; };
 		864FA9062C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9052C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift */; };
 		864FA9082C3D20560051EA36 /* MypageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9072C3D20560051EA36 /* MypageHeaderView.swift */; };
+		864FA90A2C3D20910051EA36 /* MypageOptionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */; };
 		86685C522C3BC67D00C080C4 /* UnivSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */; };
 		86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */; };
 		86685C582C3BD89500C080C4 /* UnivCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */; };
@@ -108,6 +109,7 @@
 		864FA9022C3D1F7B0051EA36 /* MypageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageViewController.swift; sourceTree = "<group>"; };
 		864FA9052C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageHankkiCollectionViewCell.swift; sourceTree = "<group>"; };
 		864FA9072C3D20560051EA36 /* MypageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageHeaderView.swift; sourceTree = "<group>"; };
+		864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageOptionCollectionViewCell.swift; sourceTree = "<group>"; };
 		86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewModel.swift; sourceTree = "<group>"; };
 		86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewController.swift; sourceTree = "<group>"; };
 		86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -425,6 +427,7 @@
 			children = (
 				864FA9052C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift */,
 				864FA9072C3D20560051EA36 /* MypageHeaderView.swift */,
+				864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -623,6 +626,7 @@
 				83DBEDC82C256AD00042BA48 /* NSObject+.swift in Sources */,
 				83DBEDB62C2566380042BA48 /* FontLiterals.swift in Sources */,
 				83DBED762C255A180042BA48 /* AppDelegate.swift in Sources */,
+				864FA90A2C3D20910051EA36 /* MypageOptionCollectionViewCell.swift in Sources */,
 				83DBEDCC2C256B080042BA48 /* UILabel+.swift in Sources */,
 				864FA9062C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift in Sources */,
 				861704F72C38304D00D99E50 /* AlertViewController.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		864FA90C2C3D20BE0051EA36 /* MypageQuitFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */; };
 		864FA90E2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA90D2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift */; };
 		864FA9122C3D34B80051EA36 /* MypageCollectionViewCellEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9112C3D34B80051EA36 /* MypageCollectionViewCellEnum.swift */; };
+		864FA91C2C3D63400051EA36 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA91B2C3D63400051EA36 /* BottomButtonView.swift */; };
 		86685C522C3BC67D00C080C4 /* UnivSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */; };
 		86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */; };
 		86685C582C3BD89500C080C4 /* UnivCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */; };
@@ -116,6 +117,7 @@
 		864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageQuitFooterView.swift; sourceTree = "<group>"; };
 		864FA90D2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageZipCollectionViewCell.swift; sourceTree = "<group>"; };
 		864FA9112C3D34B80051EA36 /* MypageCollectionViewCellEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageCollectionViewCellEnum.swift; sourceTree = "<group>"; };
+		864FA91B2C3D63400051EA36 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
 		86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewModel.swift; sourceTree = "<group>"; };
 		86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewController.swift; sourceTree = "<group>"; };
 		86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -398,6 +400,7 @@
 			isa = PBXGroup;
 			children = (
 				83DBEDB82C25666E0042BA48 /* MainButton.swift */,
+				864FA91B2C3D63400051EA36 /* BottomButtonView.swift */,
 			);
 			path = HankkiButtons;
 			sourceTree = "<group>";
@@ -642,6 +645,7 @@
 				864FA9062C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift in Sources */,
 				861704F72C38304D00D99E50 /* AlertViewController.swift in Sources */,
 				83DBEDB22C2566230042BA48 /* ImageLiterals.swift in Sources */,
+				864FA91C2C3D63400051EA36 /* BottomButtonView.swift in Sources */,
 				83DBEDB42C2566300042BA48 /* StringLiterals.swift in Sources */,
 				83DBED782C255A180042BA48 /* SceneDelegate.swift in Sources */,
 				864FA9082C3D20560051EA36 /* MypageHeaderView.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		864FA90A2C3D20910051EA36 /* MypageOptionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */; };
 		864FA90C2C3D20BE0051EA36 /* MypageQuitFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */; };
 		864FA90E2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA90D2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift */; };
+		864FA9122C3D34B80051EA36 /* MypageCollectionViewCellEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9112C3D34B80051EA36 /* MypageCollectionViewCellEnum.swift */; };
 		86685C522C3BC67D00C080C4 /* UnivSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */; };
 		86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */; };
 		86685C582C3BD89500C080C4 /* UnivCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */; };
@@ -114,6 +115,7 @@
 		864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageOptionCollectionViewCell.swift; sourceTree = "<group>"; };
 		864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageQuitFooterView.swift; sourceTree = "<group>"; };
 		864FA90D2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageZipCollectionViewCell.swift; sourceTree = "<group>"; };
+		864FA9112C3D34B80051EA36 /* MypageCollectionViewCellEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageCollectionViewCellEnum.swift; sourceTree = "<group>"; };
 		86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewModel.swift; sourceTree = "<group>"; };
 		86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewController.swift; sourceTree = "<group>"; };
 		86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -422,6 +424,7 @@
 			children = (
 				864FA9042C3D20030051EA36 /* Cell */,
 				864FA9022C3D1F7B0051EA36 /* MypageViewController.swift */,
+				864FA9112C3D34B80051EA36 /* MypageCollectionViewCellEnum.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -625,6 +628,7 @@
 				864FA9032C3D1F7B0051EA36 /* MypageViewController.swift in Sources */,
 				83DBEDBB2C2566830042BA48 /* AuthenticationAdapterProtocol.swift in Sources */,
 				864FA90C2C3D20BE0051EA36 /* MypageQuitFooterView.swift in Sources */,
+				864FA9122C3D34B80051EA36 /* MypageCollectionViewCellEnum.swift in Sources */,
 				A2B599182C39B5C8004B7E4E /* BlackToastView.swift in Sources */,
 				83DBED7A2C255A180042BA48 /* ViewController.swift in Sources */,
 				83DBEDA02C25651C0042BA48 /* request.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		864FA9082C3D20560051EA36 /* MypageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9072C3D20560051EA36 /* MypageHeaderView.swift */; };
 		864FA90A2C3D20910051EA36 /* MypageOptionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */; };
 		864FA90C2C3D20BE0051EA36 /* MypageQuitFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */; };
+		864FA90E2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA90D2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift */; };
 		86685C522C3BC67D00C080C4 /* UnivSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */; };
 		86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */; };
 		86685C582C3BD89500C080C4 /* UnivCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */; };
@@ -112,6 +113,7 @@
 		864FA9072C3D20560051EA36 /* MypageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageHeaderView.swift; sourceTree = "<group>"; };
 		864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageOptionCollectionViewCell.swift; sourceTree = "<group>"; };
 		864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageQuitFooterView.swift; sourceTree = "<group>"; };
+		864FA90D2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageZipCollectionViewCell.swift; sourceTree = "<group>"; };
 		86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewModel.swift; sourceTree = "<group>"; };
 		86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewController.swift; sourceTree = "<group>"; };
 		86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -431,6 +433,7 @@
 				864FA9072C3D20560051EA36 /* MypageHeaderView.swift */,
 				864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */,
 				864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */,
+				864FA90D2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -658,6 +661,7 @@
 				83DBEDC62C256A7A0042BA48 /* UIView+.swift in Sources */,
 				86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */,
 				83DBEDB02C2566120042BA48 /* UIStackView+.swift in Sources */,
+				864FA90E2C3D20FF0051EA36 /* MypageZipCollectionViewCell.swift in Sources */,
 				83DBED962C2564AC0042BA48 /* HomeViewController.swift in Sources */,
 				A2F27C042C353AEF001E6514 /* BaseView.swift in Sources */,
 				A2FF94102C31660E001ADA03 /* BaseTableViewCell.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		861704F72C38304D00D99E50 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861704F62C38304D00D99E50 /* AlertViewController.swift */; };
 		864A89BC2C3B350900140B63 /* AlertStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864A89BB2C3B350900140B63 /* AlertStyle.swift */; };
 		864FA9032C3D1F7B0051EA36 /* MypageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9022C3D1F7B0051EA36 /* MypageViewController.swift */; };
+		864FA9062C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9052C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift */; };
+		864FA9082C3D20560051EA36 /* MypageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9072C3D20560051EA36 /* MypageHeaderView.swift */; };
 		86685C522C3BC67D00C080C4 /* UnivSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */; };
 		86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */; };
 		86685C582C3BD89500C080C4 /* UnivCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */; };
@@ -104,6 +106,8 @@
 		861704F62C38304D00D99E50 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		864A89BB2C3B350900140B63 /* AlertStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStyle.swift; sourceTree = "<group>"; };
 		864FA9022C3D1F7B0051EA36 /* MypageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageViewController.swift; sourceTree = "<group>"; };
+		864FA9052C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageHankkiCollectionViewCell.swift; sourceTree = "<group>"; };
+		864FA9072C3D20560051EA36 /* MypageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageHeaderView.swift; sourceTree = "<group>"; };
 		86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewModel.swift; sourceTree = "<group>"; };
 		86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewController.swift; sourceTree = "<group>"; };
 		86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -410,9 +414,19 @@
 		864FA9012C3D1F700051EA36 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				864FA9042C3D20030051EA36 /* Cell */,
 				864FA9022C3D1F7B0051EA36 /* MypageViewController.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		864FA9042C3D20030051EA36 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				864FA9052C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift */,
+				864FA9072C3D20560051EA36 /* MypageHeaderView.swift */,
+			);
+			path = Cell;
 			sourceTree = "<group>";
 		};
 		86685C4D2C3BC63500C080C4 /* UnivSelect */ = {
@@ -610,10 +624,12 @@
 				83DBEDB62C2566380042BA48 /* FontLiterals.swift in Sources */,
 				83DBED762C255A180042BA48 /* AppDelegate.swift in Sources */,
 				83DBEDCC2C256B080042BA48 /* UILabel+.swift in Sources */,
+				864FA9062C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift in Sources */,
 				861704F72C38304D00D99E50 /* AlertViewController.swift in Sources */,
 				83DBEDB22C2566230042BA48 /* ImageLiterals.swift in Sources */,
 				83DBEDB42C2566300042BA48 /* StringLiterals.swift in Sources */,
 				83DBED782C255A180042BA48 /* SceneDelegate.swift in Sources */,
+				864FA9082C3D20560051EA36 /* MypageHeaderView.swift in Sources */,
 				83DBEDCE2C256B180042BA48 /* UIButton+.swift in Sources */,
 				83DBEDB92C25666E0042BA48 /* MainButton.swift in Sources */,
 				83DA28962C3851BB004819FA /* HankkiNavigationType.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		864FA9062C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9052C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift */; };
 		864FA9082C3D20560051EA36 /* MypageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9072C3D20560051EA36 /* MypageHeaderView.swift */; };
 		864FA90A2C3D20910051EA36 /* MypageOptionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */; };
+		864FA90C2C3D20BE0051EA36 /* MypageQuitFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */; };
 		86685C522C3BC67D00C080C4 /* UnivSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */; };
 		86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */; };
 		86685C582C3BD89500C080C4 /* UnivCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */; };
@@ -110,6 +111,7 @@
 		864FA9052C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageHankkiCollectionViewCell.swift; sourceTree = "<group>"; };
 		864FA9072C3D20560051EA36 /* MypageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageHeaderView.swift; sourceTree = "<group>"; };
 		864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageOptionCollectionViewCell.swift; sourceTree = "<group>"; };
+		864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageQuitFooterView.swift; sourceTree = "<group>"; };
 		86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewModel.swift; sourceTree = "<group>"; };
 		86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewController.swift; sourceTree = "<group>"; };
 		86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -428,6 +430,7 @@
 				864FA9052C3D20150051EA36 /* MypageHankkiCollectionViewCell.swift */,
 				864FA9072C3D20560051EA36 /* MypageHeaderView.swift */,
 				864FA9092C3D20910051EA36 /* MypageOptionCollectionViewCell.swift */,
+				864FA90B2C3D20BE0051EA36 /* MypageQuitFooterView.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -618,6 +621,7 @@
 				838BEB032C38196300AAA153 /* TabBarItem.swift in Sources */,
 				864FA9032C3D1F7B0051EA36 /* MypageViewController.swift in Sources */,
 				83DBEDBB2C2566830042BA48 /* AuthenticationAdapterProtocol.swift in Sources */,
+				864FA90C2C3D20BE0051EA36 /* MypageQuitFooterView.swift in Sources */,
 				A2B599182C39B5C8004B7E4E /* BlackToastView.swift in Sources */,
 				83DBED7A2C255A180042BA48 /* ViewController.swift in Sources */,
 				83DBEDA02C25651C0042BA48 /* request.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		83DBEDD22C256B7A0042BA48 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DBEDD12C256B7A0042BA48 /* UIColor+.swift */; };
 		861704F72C38304D00D99E50 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861704F62C38304D00D99E50 /* AlertViewController.swift */; };
 		864A89BC2C3B350900140B63 /* AlertStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864A89BB2C3B350900140B63 /* AlertStyle.swift */; };
+		864FA9032C3D1F7B0051EA36 /* MypageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FA9022C3D1F7B0051EA36 /* MypageViewController.swift */; };
 		86685C522C3BC67D00C080C4 /* UnivSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */; };
 		86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */; };
 		86685C582C3BD89500C080C4 /* UnivCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */; };
@@ -102,6 +103,7 @@
 		83DBEDD12C256B7A0042BA48 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		861704F62C38304D00D99E50 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		864A89BB2C3B350900140B63 /* AlertStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStyle.swift; sourceTree = "<group>"; };
+		864FA9022C3D1F7B0051EA36 /* MypageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageViewController.swift; sourceTree = "<group>"; };
 		86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewModel.swift; sourceTree = "<group>"; };
 		86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewController.swift; sourceTree = "<group>"; };
 		86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -197,6 +199,7 @@
 		83DBED8A2C25645B0042BA48 /* Present */ = {
 			isa = PBXGroup;
 			children = (
+				864FA9002C3D1F650051EA36 /* Mypage */,
 				86685C4D2C3BC63500C080C4 /* UnivSelect */,
 				A22D20C92C3165B6001AFAC6 /* Base */,
 				83DBED792C255A180042BA48 /* ViewController.swift */,
@@ -396,6 +399,22 @@
 			path = HankkiAlerts;
 			sourceTree = "<group>";
 		};
+		864FA9002C3D1F650051EA36 /* Mypage */ = {
+			isa = PBXGroup;
+			children = (
+				864FA9012C3D1F700051EA36 /* View */,
+			);
+			path = Mypage;
+			sourceTree = "<group>";
+		};
+		864FA9012C3D1F700051EA36 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				864FA9022C3D1F7B0051EA36 /* MypageViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		86685C4D2C3BC63500C080C4 /* UnivSelect */ = {
 			isa = PBXGroup;
 			children = (
@@ -580,6 +599,7 @@
 				A2DEBF452C3BD0DD00DE14A9 /* UIScreen+.swift in Sources */,
 				838BEB052C382B0700AAA153 /* TabBarController.swift in Sources */,
 				838BEB032C38196300AAA153 /* TabBarItem.swift in Sources */,
+				864FA9032C3D1F7B0051EA36 /* MypageViewController.swift in Sources */,
 				83DBEDBB2C2566830042BA48 /* AuthenticationAdapterProtocol.swift in Sources */,
 				A2B599182C39B5C8004B7E4E /* BlackToastView.swift in Sources */,
 				83DBED7A2C255A180042BA48 /* ViewController.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
+++ b/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = /*TabBarController()*/ UnivSelectViewController()
+        window?.rootViewController = TabBarController()
         window?.makeKeyAndVisible()
     }
     

--- a/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
+++ b/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = TabBarController()
+        window?.rootViewController = /*TabBarController()*/ UnivSelectViewController()
         window?.makeKeyAndVisible()
     }
     

--- a/Hankkijogbo/Hankkijogbo/Global/Components/HankkiButtons/BottomButtonView.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/HankkiButtons/BottomButtonView.swift
@@ -1,0 +1,167 @@
+//
+//  BottomButtonView.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 7/9/24.
+//
+
+import UIKit
+
+final class BottomButtonView: BaseView {
+    
+    // MARK: - Properties
+    
+    typealias ButtonAction = () -> Void
+    
+    let primaryButtonText: String
+    let lineButtonText: String
+    
+    var primaryButtonHandler: ButtonAction?
+    var lineButtonHandler: ButtonAction?
+    
+    // MARK: - UI Properties
+    
+    private let primaryButton: UIButton = UIButton()
+    private let lineButton: UIButton = UIButton()
+    
+    private let bottomButtonViewGradient = UIView()
+    
+    // MARK: - Life Cycle
+    
+    init(frame: CGRect = .zero,
+         primaryButtonText: String,
+         lineButtonText: String = "",
+         primaryButtonHandler: ButtonAction? = nil,
+         lineButtonHandler: ButtonAction? = nil
+    ) {
+        self.primaryButtonText = primaryButtonText
+        self.lineButtonText = lineButtonText
+        self.primaryButtonHandler = primaryButtonHandler
+        self.lineButtonHandler = lineButtonHandler
+        super.init(frame: frame)
+    
+        setupButtonAction()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setupBottomButtonViewGradient()
+    }
+    
+    override func setupStyle() {
+        primaryButton.do {
+            if let attributedTitle = UILabel.setupAttributedText(
+                for: PretendardStyle.subtitle3,
+                withText: primaryButtonText,
+                color: .hankkiWhite
+            ) {
+                $0.setAttributedTitle(attributedTitle, for: .normal)
+            }
+            $0.backgroundColor = .hankkiRedLight2
+            $0.layer.cornerRadius = 16
+            $0.isEnabled = false
+        }
+        
+        lineButton.do {
+            $0.setTitle(lineButtonText, for: .normal)
+            $0.titleLabel?.font = .setupPretendardStyle(of: .button)
+            $0.setTitleColor(.gray400, for: .normal)
+            $0.setUnderline()
+        }
+    }
+    
+    override func setupHierarchy() {
+        self.addSubviews(
+            bottomButtonViewGradient
+        )
+        if !primaryButtonText.isEmpty {
+            self.addSubview(primaryButton)
+        }
+        if !lineButtonText.isEmpty {
+            self.addSubview(lineButton)
+        }
+    }
+    
+    override func setupLayout() {
+        bottomButtonViewGradient.snp.makeConstraints {
+            $0.leading.trailing.top.equalToSuperview()
+            $0.height.equalTo(154)
+        }
+
+        if !primaryButtonText.isEmpty {
+            primaryButton.snp.makeConstraints {
+                $0.top.bottom.equalToSuperview().inset(50)
+                $0.leading.trailing.equalToSuperview().inset(22)
+                $0.height.equalTo(54)
+            }
+        }
+        
+        if !lineButtonText.isEmpty {
+            lineButton.snp.makeConstraints {
+                $0.top.equalTo(primaryButton.snp.bottom).offset(14)
+                $0.centerX.equalToSuperview()
+                $0.height.equalTo(18)
+            }
+        }
+    }
+}
+
+private extension BottomButtonView {
+    func setupBottomButtonViewGradient() {
+        let gradient = CAGradientLayer()
+        
+        gradient.do {
+            $0.colors = [
+                UIColor.white.withAlphaComponent(0).cgColor,
+                UIColor.white.cgColor,
+                UIColor.white.cgColor
+              ]
+            $0.locations = [0.0, 0.3, 1.0]
+            $0.startPoint = CGPoint(x: 0.5, y: 0.0)
+            $0.endPoint = CGPoint(x: 0.5, y: 1.0)
+            $0.frame = self.bounds
+            
+        }
+        
+        bottomButtonViewGradient.layer.addSublayer(gradient)
+    }
+    
+    @objc func primaryButtonDidTap() {
+        if let primaryButtonHandler {
+            return primaryButtonHandler()
+        }
+    }
+    
+    @objc func lineButtonDidTap() {
+        if let lineButtonHandler {
+            return lineButtonHandler()
+        }
+    }
+    
+    func setupButtonAction() {
+        primaryButton.addTarget(self, action: #selector(primaryButtonDidTap), for: .touchUpInside)
+        lineButton.addTarget(self, action: #selector(lineButtonDidTap), for: .touchUpInside)
+    }
+   
+}
+
+extension BottomButtonView {
+    func setupEnabledDoneButton() {
+        primaryButton.do {
+            $0.backgroundColor = .hankkiRed
+            $0.isEnabled = true
+        }
+    }
+    
+    func setupDisabledDoneButton() {
+        primaryButton.do {
+            $0.backgroundColor = .hankkiRedLight
+            $0.isEnabled = false
+        }
+    }
+}
+

--- a/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarItem.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarItem.swift
@@ -52,7 +52,7 @@ enum TabBarItem: CaseIterable {
         switch self {
         case .home: return ViewController()
         case .report: return ViewController()
-        case .mypage: return ViewController()
+        case .mypage: return MypageViewController()
         }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UIView+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UIView+.swift
@@ -44,4 +44,10 @@ extension UIView {
         self.layer.shadowRadius = radius
         self.layer.shadowOffset = offset
     }
+    
+    /// width 기준으로 종횡비를 유지해  view의 CGsize를 계산하는 함수
+    static func convertByAspectRatioHeight(_ newWidth: CGFloat, width: CGFloat, height: CGFloat) -> CGFloat {
+        let newHeight: CGFloat = newWidth / width * height
+        return newHeight
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageHankkiCollectionViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageHankkiCollectionViewCell.swift
@@ -1,8 +1,33 @@
 //
-//  MypageHankkiCollectionViewCell.swift
+//  MypageZipCollectionViewCell.swift
 //  Hankkijogbo
 //
 //  Created by 심서현 on 7/9/24.
 //
 
-import Foundation
+import UIKit
+
+final class MypageHankkiCollectionViewCell: BaseCollectionViewCell {
+    
+    // MARK: - UI Properties
+
+    let imageView: UIImageView = UIImageView()
+    
+    override func setupStyle() {
+        imageView.do {
+            $0.backgroundColor = .gray200
+            $0.layer.cornerRadius = 12
+        }
+    }
+    
+    override func setupHierarchy() {
+        self.addSubviews(imageView)
+    }
+    
+    override func setupLayout() {
+        imageView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview()
+        }
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageHankkiCollectionViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageHankkiCollectionViewCell.swift
@@ -1,0 +1,8 @@
+//
+//  MypageHankkiCollectionViewCell.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 7/9/24.
+//
+
+import Foundation

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageHeaderView.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageHeaderView.swift
@@ -1,0 +1,74 @@
+//
+//  MypageHeaderView.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 7/9/24.
+//
+
+import UIKit
+
+final class MypageHeaderView: UICollectionReusableView {
+    
+    // MARK: - Properties
+    
+    let profileImage: String = "image"
+    let profileNameText: String = "한끼 줍쇼"
+    
+    // MARK: - UI Properties
+    
+    let profileView: UIView = UIView()
+    let profileImageView: UIImageView = UIImageView()
+    let profileNameLabel: UILabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupHierarchy()
+        setupLayout()
+        setupStyle()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupStyle() {
+        profileImageView.do {
+            $0.backgroundColor = .gray400
+        }
+        
+        profileNameLabel.do {
+            $0.attributedText = UILabel.setupAttributedText(
+                for: SuiteStyle.h2,
+                withText: "\(profileNameText)님\n한끼 잘 챙겨드세요",
+                color: .gray900
+            )
+            $0.numberOfLines = 2
+            $0.textAlignment = .center
+        }
+    
+    }
+    
+    private func setupHierarchy() {
+        self.addSubviews(profileView)
+        profileView.addSubviews(profileImageView, profileNameLabel)
+    }
+    
+    private func setupLayout() {
+        profileView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+        }
+
+        profileImageView.snp.makeConstraints {
+            $0.width.height.equalTo(98)
+            $0.top.equalToSuperview().inset(10)
+            $0.centerX.equalToSuperview()
+        }
+
+        profileNameLabel.snp.makeConstraints {
+            $0.top.equalTo(profileImageView.snp.bottom).offset(10)
+            $0.bottom.equalToSuperview().inset(19)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageOptionCollectionViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageOptionCollectionViewCell.swift
@@ -7,14 +7,8 @@
 
 import UIKit
 
-struct MypageOptionCollectionViewCellStruct {
-    var title: String
-    var onTab: () -> Void
-}
-
 final class MypageOptionCollectionViewCell: BaseCollectionViewCell {
-    var onTab: (() -> Void)?
-    
+
     // MARK: - UI Properties
 
     let iconImageView: UIImageView = UIImageView()
@@ -64,8 +58,11 @@ final class MypageOptionCollectionViewCell: BaseCollectionViewCell {
 }
 
 extension MypageOptionCollectionViewCell {
-    func dataBind(data: MypageOptionCollectionViewCellStruct) {
-        onTab = data.onTab
+    struct DataStruct {
+        var title: String
+    }
+    
+    func dataBind(data: DataStruct) {
         titleLabel.text = data.title
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageOptionCollectionViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageOptionCollectionViewCell.swift
@@ -1,0 +1,71 @@
+//
+//  MypageZipCollectionViewCell.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 7/9/24.
+//
+
+import UIKit
+
+struct MypageOptionCollectionViewCellStruct {
+    var title: String
+    var onTab: () -> Void
+}
+
+final class MypageOptionCollectionViewCell: BaseCollectionViewCell {
+    var onTab: (() -> Void)?
+    
+    // MARK: - UI Properties
+
+    let iconImageView: UIImageView = UIImageView()
+    let titleLabel: UILabel = UILabel()
+    let lineView: UIView = UIView()
+    
+    override func setupStyle() {
+        iconImageView.do {
+            $0.backgroundColor = .gray500
+        }
+        
+        titleLabel.do {
+            $0.attributedText = UILabel.setupAttributedText(
+                for: PretendardStyle.body3,
+                withText: "",
+                color: .gray900
+            )
+        }
+        
+        lineView.do {
+            $0.backgroundColor = .gray200
+        }
+    }
+    
+    override func setupHierarchy() {
+        self.addSubviews(titleLabel, iconImageView, lineView)
+    }
+    
+    override func setupLayout() {
+        iconImageView.snp.makeConstraints {
+            $0.width.height.equalTo(24)
+            $0.trailing.equalToSuperview()
+            $0.top.equalToSuperview().inset(18)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.top.equalToSuperview().inset(18)
+        }
+        
+        lineView.snp.makeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.width.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+    }
+}
+
+extension MypageOptionCollectionViewCell {
+    func dataBind(data: MypageOptionCollectionViewCellStruct) {
+        onTab = data.onTab
+        titleLabel.text = data.title
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageQuitFooterView.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageQuitFooterView.swift
@@ -1,0 +1,66 @@
+//
+//  MypageQuitFooterView.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 7/9/24.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+
+final class MypageQuitFooterView: UICollectionReusableView {
+    
+    // MARK: - UI Properties
+    let buttonStackVIew: UIStackView = UIStackView()
+    let buttonLabel: UILabel = UILabel()
+    let buttonImage: UIImageView = UIImageView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupStyle() {
+        buttonStackVIew.do {
+            $0.axis = .horizontal
+            $0.alignment = .center
+            $0.spacing = 2
+            $0.layoutMargins = UIEdgeInsets(top: 14, left: 2, bottom: 14, right: 2)
+            $0.isLayoutMarginsRelativeArrangement = true
+        }
+        
+        buttonLabel.do {
+            $0.attributedText = UILabel.setupAttributedText(
+                for: PretendardStyle.body4,
+                withText: "탈퇴하기",
+                color: .gray400
+            )
+        }
+        buttonImage.do {
+            $0.backgroundColor = .gray400
+        }
+    }
+    
+    private func setupHierarchy() {
+        self.addSubviews(buttonStackVIew)
+        buttonStackVIew.addArrangedSubviews(buttonLabel, buttonImage)
+    }
+    
+    private func setupLayout() {
+        buttonStackVIew.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+        }
+        buttonImage.snp.makeConstraints {
+            $0.width.height.equalTo(16)
+        }
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageQuitFooterView.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageQuitFooterView.swift
@@ -11,6 +11,9 @@ import Then
 import SnapKit
 
 final class MypageQuitFooterView: UICollectionReusableView {
+    // MARK: - Properties
+    
+    var quitButtonHandler: (() -> Void)?
     
     // MARK: - UI Properties
     let buttonStackVIew: UIStackView = UIStackView()
@@ -23,6 +26,8 @@ final class MypageQuitFooterView: UICollectionReusableView {
         setupStyle()
         setupHierarchy()
         setupLayout()
+        
+        setupAction()
     }
     
     required init?(coder: NSCoder) {
@@ -62,5 +67,20 @@ final class MypageQuitFooterView: UICollectionReusableView {
         buttonImage.snp.makeConstraints {
             $0.width.height.equalTo(16)
         }
+    }
+}
+
+extension MypageQuitFooterView {
+    @objc func quitButtonDidTap () {
+        if let quitButtonHandler {
+            quitButtonHandler()
+        } else {
+            return
+        }
+    }
+    
+    func setupAction () {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(quitButtonDidTap))
+        buttonStackVIew.addGestureRecognizer(tapGesture)
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageZipCollectionViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/Cell/MypageZipCollectionViewCell.swift
@@ -1,0 +1,33 @@
+//
+//  MypageZipCollectionViewCell.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 7/9/24.
+//
+
+import UIKit
+
+final class MypageZipCollectionViewCell: BaseCollectionViewCell {
+    
+    // MARK: - UI Properties
+
+    let imageView: UIImageView = UIImageView()
+    
+    override func setupStyle() {
+        imageView.do {
+            $0.layer.cornerRadius = 12
+            $0.backgroundColor = .gray400
+        }
+    }
+    
+    override func setupHierarchy() {
+        self.addSubviews(imageView)
+    }
+    
+    override func setupLayout() {
+        imageView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalTo(72)
+        }
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageCollectionViewCellEnum.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageCollectionViewCellEnum.swift
@@ -24,6 +24,7 @@ extension MypageViewController {
     }
     
     func setupAction(_ section: SectionType, itemIndex: Int) {
+        print("터치")
         // TODO: - 함수 추후 변경
         switch section {
         case .zip:
@@ -64,3 +65,89 @@ extension MypageViewController {
     }
 }
 
+// MARK: - setup CollectionView Section
+
+private extension MypageViewController {
+    
+    func setupNSCollectionLayoutSection(itemSize: NSCollectionLayoutSize, groupSize: NSCollectionLayoutSize) -> NSCollectionLayoutSection {
+        let itemSize = itemSize
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = groupSize
+        
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        let section = NSCollectionLayoutSection(group: group)
+        
+        return section
+    }
+    
+    func setupZipSection() -> NSCollectionLayoutSection {
+        let itemWidth: CGFloat = (375 - 22*2)
+        
+        let section: NSCollectionLayoutSection = setupNSCollectionLayoutSection(
+            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(72)),
+            groupSize: NSCollectionLayoutSize(widthDimension: .absolute(itemWidth), heightDimension: .absolute(UIView.convertByAspectRatioHeight(itemWidth, width: 331, height: 72)))
+        )
+        
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(196))
+        
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        
+        section.boundarySupplementaryItems = [header]
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
+        
+        return section
+    }
+    
+    func setupHankkiSection() -> NSCollectionLayoutSection {
+        let itemWidth: CGFloat = ((375 - 22*2) / 2) - 20
+        
+        let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(itemWidth), heightDimension: .fractionalHeight(1.0))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(UIView.convertByAspectRatioHeight(itemWidth, width: 155, height: 95)
+        ))
+        
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitem: item,
+            count: 2
+        )
+        group.interItemSpacing = .flexible(20)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 20, leading: 22, bottom: 10, trailing: 22)
+        
+        return section
+    }
+    
+    func setupOptionSection() -> NSCollectionLayoutSection {
+        let section: NSCollectionLayoutSection = setupNSCollectionLayoutSection(
+            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(60)),
+            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(60))
+        )
+
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
+
+        let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(48))
+        
+        let footer = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: footerSize,
+            elementKind: UICollectionView.elementKindSectionFooter,
+            alignment: .bottomTrailing
+        )
+        
+        section.boundarySupplementaryItems = [footer]
+
+        return section
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageCollectionViewCellEnum.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageCollectionViewCellEnum.swift
@@ -24,7 +24,6 @@ extension MypageViewController {
     }
     
     func setupAction(_ section: SectionType, itemIndex: Int) {
-        print("터치")
         // TODO: - 함수 추후 변경
         switch section {
         case .zip:
@@ -86,11 +85,9 @@ private extension MypageViewController {
     }
     
     func setupZipSection() -> NSCollectionLayoutSection {
-        let itemWidth: CGFloat = (375 - 22*2)
-        
         let section: NSCollectionLayoutSection = setupNSCollectionLayoutSection(
             itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(72)),
-            groupSize: NSCollectionLayoutSize(widthDimension: .absolute(itemWidth), heightDimension: .absolute(UIView.convertByAspectRatioHeight(itemWidth, width: 331, height: 72)))
+            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(UIView.convertByAspectRatioHeight(UIScreen.getDeviceWidth() - 22*2, width: 331, height: 72)))
         )
         
         let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(196))

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageCollectionViewCellEnum.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageCollectionViewCellEnum.swift
@@ -1,0 +1,66 @@
+//
+//  MypageCollectionViewCellType.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 7/9/24.
+//
+
+import UIKit
+
+extension MypageViewController {
+    enum SectionType: Int, CaseIterable {
+        case zip, hankki, option
+        
+        var numberOfItemsInSection: Int {
+            switch self {
+            case .zip:
+                1
+            case .hankki:
+                2
+            case .option:
+                3
+            }
+        }
+    }
+    
+    func setupAction(_ section: SectionType, itemIndex: Int) {
+        // TODO: - 함수 추후 변경
+        switch section {
+        case .zip:
+            print("나의 한끼 족보로 이동")
+            
+        case .hankki:
+            print("제보하거나 좋아요한 한끼 식당 리스트로 이동")
+            
+        case .option:
+            switch itemIndex {
+            case 0:
+                print("FAQ로 이동")
+            case 1:
+                print("1:1 문의로 이동")
+            case 2:
+                self.showAlert(
+                    image: "dummy",
+                    titleText: "정말 로그아웃 하실 건가요?",
+                    subText: "Apple 계정을 로그아웃합니다",
+                    secondaryButtonText: "돌아가기",
+                    primaryButtonText: "로그아웃"
+                )
+            default:
+                return
+            }
+        }
+    }
+    
+    func setupSection(_ section: SectionType) -> NSCollectionLayoutSection {
+        switch section {
+        case .zip:
+        return setupZipSection()
+        case .hankki:
+            return setupHankkiSection()
+        case .option:
+            return setupOptionSection()
+        }
+    }
+}
+

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageViewController.swift
@@ -11,24 +11,16 @@ final class MypageViewController: BaseViewController {
     
     // MARK: - Properties
     
-    lazy var optionList: [MypageOptionCollectionViewCellStruct] = [
-        MypageOptionCollectionViewCellStruct(title: "FAQ", onTab: {print("FAQ로 이동")}),
-        MypageOptionCollectionViewCellStruct(title: "1:1 문의", onTab: {print("1:1 문의로 이동")}),
-        MypageOptionCollectionViewCellStruct(title: "로그아웃", onTab: {
-            self.showAlert(
-                image: "dummy",
-                titleText: "정말 로그아웃 하실 건가요?",
-                subText: "Apple 계정을 로그아웃합니다",
-                secondaryButtonText: "돌아가기",
-                primaryButtonText: "로그아웃"
-            )
-        })
+    private lazy var optionList: [MypageOptionCollectionViewCell.DataStruct] = [
+        MypageOptionCollectionViewCell.DataStruct(title: "FAQ"),
+        MypageOptionCollectionViewCell.DataStruct(title: "1:1 문의"),
+        MypageOptionCollectionViewCell.DataStruct(title: "로그아웃")
     ]
     
     // MARK: - UI Properties
     
     lazy var layout = UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
-        return self.setupCollectionViewSection(for: sectionIndex)
+        return self.setupCollectionViewSection(for: SectionType(rawValue: sectionIndex)!)
     }
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
     
@@ -53,7 +45,6 @@ final class MypageViewController: BaseViewController {
 }
 
 private extension MypageViewController {
-    
     func setupRegister() {
         collectionView.register(MypageZipCollectionViewCell.self, forCellWithReuseIdentifier: MypageZipCollectionViewCell.className)
         collectionView.register(MypageHankkiCollectionViewCell.self, forCellWithReuseIdentifier: MypageHankkiCollectionViewCell.className)
@@ -67,131 +58,18 @@ private extension MypageViewController {
         collectionView.delegate = self
         collectionView.dataSource = self
     }
-    
-    func setupCollectionViewSection(for sectionIndex: Int) -> NSCollectionLayoutSection {
-        switch sectionIndex {
-        case 0:
-            return setupZipSection()
-        case 1:
-            return setupHankkiSection()
-        case 2:
-            return setupOptionSection()
-        default:
-            return setupZipSection()
-        }
-    }
-    
-    func setupSection(itemSize: NSCollectionLayoutSize, groupSize: NSCollectionLayoutSize) -> NSCollectionLayoutSection {
-        let itemSize = itemSize
-        
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        
-        let groupSize = groupSize
-        
-        let group = NSCollectionLayoutGroup.vertical(
-            layoutSize: groupSize,
-            subitems: [item]
-        )
-        let section = NSCollectionLayoutSection(group: group)
-        
-        return section
-    }
-    
-    func setupZipSection() -> NSCollectionLayoutSection {
-        let section: NSCollectionLayoutSection = setupSection(
-            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                             heightDimension: .absolute(72)),
-            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                              heightDimension: .absolute(72))
-        )
-        
-        let headerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(196)
-        )
-        
-        let header = NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: headerSize,
-            elementKind: UICollectionView.elementKindSectionHeader,
-            alignment: .top
-        )
-        
-        section.boundarySupplementaryItems = [header]
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
-        
-        return section
-    }
-    
-    func setupHankkiSection() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalHeight(1.0)
-        )
-        
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalWidth(94/(375-44))
-        )
-        
-        let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: groupSize,
-            subitem: item,
-            count: 2
-        )
-        group.interItemSpacing = .flexible(21)
-        
-        let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 19, leading: 22, bottom: 8, trailing: 22)
-        
-        return section
-    }
-    
-    func setupOptionSection() -> NSCollectionLayoutSection {
-        let section: NSCollectionLayoutSection = setupSection(
-            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                             heightDimension: .absolute(60)),
-            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                              heightDimension: .absolute(60))
-        )
-
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
-
-        let footerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(48)
-        )
-        
-        let footer = NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: footerSize,
-            elementKind: UICollectionView.elementKindSectionFooter,
-            alignment: .bottomTrailing
-        )
-        
-        section.boundarySupplementaryItems = [footer]
-
-        return section
-    }
 }
+
+// MARK: - Delegate
 
 extension MypageViewController: UICollectionViewDelegate, UICollectionViewDataSource {
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 3
+        return SectionType.allCases.count
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        switch section {
-        case 0:
-            return 1
-        case 1:
-            return 2
-        case 2:
-            return optionList.count
-        default:
-            return 0
-        }
+        return SectionType(rawValue: section)?.numberOfItemsInSection ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
@@ -202,7 +80,6 @@ extension MypageViewController: UICollectionViewDelegate, UICollectionViewDataSo
                 withReuseIdentifier: MypageHeaderView.className,
                 for: indexPath
             )
-            
             return headerView
             
         case UICollectionView.elementKindSectionFooter:
@@ -220,49 +97,120 @@ extension MypageViewController: UICollectionViewDelegate, UICollectionViewDataSo
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    
-        switch indexPath.section {
-            case 0:
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MypageZipCollectionViewCell.className, for: indexPath) as? MypageZipCollectionViewCell else {
-                    return UICollectionViewCell()
-                }
-                return cell
-                
-            case 1:
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MypageHankkiCollectionViewCell.className, for: indexPath) as? MypageHankkiCollectionViewCell else {
-                    return UICollectionViewCell()
-                }
-                return cell
-                
-            case 2:
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MypageOptionCollectionViewCell.className, for: indexPath) as? MypageOptionCollectionViewCell else {
-                    return UICollectionViewCell()
-                }
-                cell.dataBind(data: optionList[indexPath.item])
-                return cell
-                
-            default:
+        switch SectionType(rawValue: indexPath.section) {
+        case .zip:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MypageZipCollectionViewCell.className, for: indexPath) as? MypageZipCollectionViewCell else {
                 return UICollectionViewCell()
             }
+            return cell
+            
+        case .hankki:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MypageHankkiCollectionViewCell.className, for: indexPath) as? MypageHankkiCollectionViewCell else {
+                return UICollectionViewCell()
+            }
+            return cell
+            
+        case .option:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MypageOptionCollectionViewCell.className, for: indexPath) as? MypageOptionCollectionViewCell else {
+                return UICollectionViewCell()
+            }
+            cell.dataBind(data: optionList[indexPath.item])
+            return cell
+            
+        case .none:
+            return UICollectionViewCell()
+        }
     }
 }
 
 extension MypageViewController: UIGestureRecognizerDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        switch indexPath[0] {
-        //TODO: - 페이지 생기면 함수 수정
-        case 0:
-            return print("나의 한끼 족보로 이동")
+        setupAction(SectionType(rawValue: indexPath.section)!, itemIndex: indexPath.item)
+    }
+}
+
+//MARK: - setup CollectionView Section
+
+private extension MypageViewController {
+
+    func setupCollectionViewSection(for section: SectionType) -> NSCollectionLayoutSection {
+        setupSection(section)
+    }
+    
+    func setupNSCollectionLayoutSection(itemSize: NSCollectionLayoutSize, groupSize: NSCollectionLayoutSize) -> NSCollectionLayoutSection {
+        let itemSize = itemSize
         
-        case 1:
-            return print("제보하거나 좋아요한 한끼 식당 리스트로 이동")
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
-        case 2:
-            let selectedOption = optionList[indexPath.item]
-            selectedOption.onTab()
-            
-        default:
-            return
-        }
+        let groupSize = groupSize
+        
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        let section = NSCollectionLayoutSection(group: group)
+        
+        return section
+    }
+    
+    func setupZipSection() -> NSCollectionLayoutSection {
+        let section: NSCollectionLayoutSection = setupNSCollectionLayoutSection(
+            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(72)),
+            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(72))
+        )
+        
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(196))
+        
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        
+        section.boundarySupplementaryItems = [header]
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
+        
+        return section
+    }
+    
+    func setupHankkiSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalWidth(94 / ( 375-44 )))
+        
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitem: item,
+            count: 2
+        )
+        group.interItemSpacing = .flexible(21)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 19, leading: 22, bottom: 8, trailing: 22)
+        
+        return section
+    }
+    
+    func setupOptionSection() -> NSCollectionLayoutSection {
+        let section: NSCollectionLayoutSection = setupNSCollectionLayoutSection(
+            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(60)),
+            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(60))
+        )
+
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
+
+        let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(48))
+        
+        let footer = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: footerSize,
+            elementKind: UICollectionView.elementKindSectionFooter,
+            alignment: .bottomTrailing
+        )
+        
+        section.boundarySupplementaryItems = [footer]
+
+        return section
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageViewController.swift
@@ -58,6 +58,20 @@ private extension MypageViewController {
         collectionView.delegate = self
         collectionView.dataSource = self
     }
+    
+    func setupCollectionViewSection(for section: SectionType) -> NSCollectionLayoutSection {
+        setupSection(section)
+    }
+    
+    func showQuitAlert() {
+        self.showAlert(
+            image:"dummy",
+            titleText: "소중한 족보가 사라져요",
+            subText: "탈퇴 계정은 복구할 수 없어요",
+            secondaryButtonText:"돌아가기",
+            primaryButtonText: "탈퇴하기"
+        )
+    }
 }
 
 // MARK: - Delegate
@@ -87,7 +101,11 @@ extension MypageViewController: UICollectionViewDelegate, UICollectionViewDataSo
                 ofKind: kind,
                 withReuseIdentifier: MypageQuitFooterView.className,
                 for: indexPath
-            )
+            )as! MypageQuitFooterView
+            
+            footerView.quitButtonHandler = {
+                self.showQuitAlert()
+            }
             
             return footerView
         
@@ -126,91 +144,5 @@ extension MypageViewController: UICollectionViewDelegate, UICollectionViewDataSo
 extension MypageViewController: UIGestureRecognizerDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         setupAction(SectionType(rawValue: indexPath.section)!, itemIndex: indexPath.item)
-    }
-}
-
-//MARK: - setup CollectionView Section
-
-private extension MypageViewController {
-
-    func setupCollectionViewSection(for section: SectionType) -> NSCollectionLayoutSection {
-        setupSection(section)
-    }
-    
-    func setupNSCollectionLayoutSection(itemSize: NSCollectionLayoutSize, groupSize: NSCollectionLayoutSize) -> NSCollectionLayoutSection {
-        let itemSize = itemSize
-        
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        
-        let groupSize = groupSize
-        
-        let group = NSCollectionLayoutGroup.vertical(
-            layoutSize: groupSize,
-            subitems: [item]
-        )
-        let section = NSCollectionLayoutSection(group: group)
-        
-        return section
-    }
-    
-    func setupZipSection() -> NSCollectionLayoutSection {
-        let section: NSCollectionLayoutSection = setupNSCollectionLayoutSection(
-            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(72)),
-            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(72))
-        )
-        
-        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(196))
-        
-        let header = NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: headerSize,
-            elementKind: UICollectionView.elementKindSectionHeader,
-            alignment: .top
-        )
-        
-        section.boundarySupplementaryItems = [header]
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
-        
-        return section
-    }
-    
-    func setupHankkiSection() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
-        
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalWidth(94 / ( 375-44 )))
-        
-        let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: groupSize,
-            subitem: item,
-            count: 2
-        )
-        group.interItemSpacing = .flexible(21)
-        
-        let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 19, leading: 22, bottom: 8, trailing: 22)
-        
-        return section
-    }
-    
-    func setupOptionSection() -> NSCollectionLayoutSection {
-        let section: NSCollectionLayoutSection = setupNSCollectionLayoutSection(
-            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(60)),
-            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(60))
-        )
-
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
-
-        let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(48))
-        
-        let footer = NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: footerSize,
-            elementKind: UICollectionView.elementKindSectionFooter,
-            alignment: .bottomTrailing
-        )
-        
-        section.boundarySupplementaryItems = [footer]
-
-        return section
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageViewController.swift
@@ -65,10 +65,10 @@ private extension MypageViewController {
     
     func showQuitAlert() {
         self.showAlert(
-            image:"dummy",
+            image: "dummy",
             titleText: "소중한 족보가 사라져요",
             subText: "탈퇴 계정은 복구할 수 없어요",
-            secondaryButtonText:"돌아가기",
+            secondaryButtonText: "돌아가기",
             primaryButtonText: "탈퇴하기"
         )
     }

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageViewController.swift
@@ -1,0 +1,268 @@
+//
+//  MypageViewController.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 7/8/24.
+//
+
+import UIKit
+
+final class MypageViewController: BaseViewController {
+    
+    // MARK: - Properties
+    
+    lazy var optionList: [MypageOptionCollectionViewCellStruct] = [
+        MypageOptionCollectionViewCellStruct(title: "FAQ", onTab: {print("FAQ로 이동")}),
+        MypageOptionCollectionViewCellStruct(title: "1:1 문의", onTab: {print("1:1 문의로 이동")}),
+        MypageOptionCollectionViewCellStruct(title: "로그아웃", onTab: {
+            self.showAlert(
+                image: "dummy",
+                titleText: "정말 로그아웃 하실 건가요?",
+                subText: "Apple 계정을 로그아웃합니다",
+                secondaryButtonText: "돌아가기",
+                primaryButtonText: "로그아웃"
+            )
+        })
+    ]
+    
+    // MARK: - UI Properties
+    
+    lazy var layout = UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
+        return self.setupCollectionViewSection(for: sectionIndex)
+    }
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupRegister()
+        setupDelegate()
+    }
+    
+    override func setupHierarchy() {
+        view.addSubviews(collectionView)
+    }
+    
+    override func setupLayout() {
+        collectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+private extension MypageViewController {
+    
+    func setupRegister() {
+        collectionView.register(MypageZipCollectionViewCell.self, forCellWithReuseIdentifier: MypageZipCollectionViewCell.className)
+        collectionView.register(MypageHankkiCollectionViewCell.self, forCellWithReuseIdentifier: MypageHankkiCollectionViewCell.className)
+        collectionView.register(MypageOptionCollectionViewCell.self, forCellWithReuseIdentifier: MypageOptionCollectionViewCell.className)
+        
+        collectionView.register(MypageHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: MypageHeaderView.className)
+        collectionView.register(MypageQuitFooterView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: MypageQuitFooterView.className)
+    }
+    
+    func setupDelegate() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+    }
+    
+    func setupCollectionViewSection(for sectionIndex: Int) -> NSCollectionLayoutSection {
+        switch sectionIndex {
+        case 0:
+            return setupZipSection()
+        case 1:
+            return setupHankkiSection()
+        case 2:
+            return setupOptionSection()
+        default:
+            return setupZipSection()
+        }
+    }
+    
+    func setupSection(itemSize: NSCollectionLayoutSize, groupSize: NSCollectionLayoutSize) -> NSCollectionLayoutSection {
+        let itemSize = itemSize
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = groupSize
+        
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        let section = NSCollectionLayoutSection(group: group)
+        
+        return section
+    }
+    
+    func setupZipSection() -> NSCollectionLayoutSection {
+        let section: NSCollectionLayoutSection = setupSection(
+            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                             heightDimension: .absolute(72)),
+            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .absolute(72))
+        )
+        
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(196)
+        )
+        
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        
+        section.boundarySupplementaryItems = [header]
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
+        
+        return section
+    }
+    
+    func setupHankkiSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalWidth(94/(375-44))
+        )
+        
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitem: item,
+            count: 2
+        )
+        group.interItemSpacing = .flexible(21)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 19, leading: 22, bottom: 8, trailing: 22)
+        
+        return section
+    }
+    
+    func setupOptionSection() -> NSCollectionLayoutSection {
+        let section: NSCollectionLayoutSection = setupSection(
+            itemSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                             heightDimension: .absolute(60)),
+            groupSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .absolute(60))
+        )
+
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 22, bottom: 0, trailing: 22)
+
+        let footerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(48)
+        )
+        
+        let footer = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: footerSize,
+            elementKind: UICollectionView.elementKindSectionFooter,
+            alignment: .bottomTrailing
+        )
+        
+        section.boundarySupplementaryItems = [footer]
+
+        return section
+    }
+}
+
+extension MypageViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 3
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        switch section {
+        case 0:
+            return 1
+        case 1:
+            return 2
+        case 2:
+            return optionList.count
+        default:
+            return 0
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        switch kind {
+        case UICollectionView.elementKindSectionHeader:
+            let headerView = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: MypageHeaderView.className,
+                for: indexPath
+            )
+            
+            return headerView
+            
+        case UICollectionView.elementKindSectionFooter:
+            let footerView = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: MypageQuitFooterView.className,
+                for: indexPath
+            )
+            
+            return footerView
+        
+        default:
+            fatalError("Unexpected element kind")
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    
+        switch indexPath.section {
+            case 0:
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MypageZipCollectionViewCell.className, for: indexPath) as? MypageZipCollectionViewCell else {
+                    return UICollectionViewCell()
+                }
+                return cell
+                
+            case 1:
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MypageHankkiCollectionViewCell.className, for: indexPath) as? MypageHankkiCollectionViewCell else {
+                    return UICollectionViewCell()
+                }
+                return cell
+                
+            case 2:
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MypageOptionCollectionViewCell.className, for: indexPath) as? MypageOptionCollectionViewCell else {
+                    return UICollectionViewCell()
+                }
+                cell.dataBind(data: optionList[indexPath.item])
+                return cell
+                
+            default:
+                return UICollectionViewCell()
+            }
+    }
+}
+
+extension MypageViewController: UIGestureRecognizerDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        switch indexPath[0] {
+        //TODO: - 페이지 생기면 함수 수정
+        case 0:
+            return print("나의 한끼 족보로 이동")
+        
+        case 1:
+            return print("제보하거나 좋아요한 한끼 식당 리스트로 이동")
+        
+        case 2:
+            let selectedOption = optionList[indexPath.item]
+            selectedOption.onTab()
+            
+        default:
+            return
+        }
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Present/UnivSelect/View/UnivCollectionViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/UnivSelect/View/UnivCollectionViewCell.swift
@@ -60,7 +60,7 @@ final class UnivCollectionViewCell: BaseCollectionViewCell {
 extension UnivCollectionViewCell {
     func dataBind(_ univText: String, isFinal: Bool) {
         univLabel.text = univText
-        
+    
         if isFinal {
             setupFinalStyle()
         }

--- a/Hankkijogbo/Hankkijogbo/Present/UnivSelect/View/UnivSelectViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/UnivSelect/View/UnivSelectViewController.swift
@@ -21,11 +21,12 @@ final class UnivSelectViewController: BaseViewController {
     private let headerTitleLabel: UILabel = UILabel()
     private let headerContentLabel: UILabel = UILabel()
     
-    private let bottomButtonView: UIView = UIView()
-    private let doneButton: UIButton = UIButton()
-    private let laterButton: UIButton = UIButton()
-    
-    private let bottomButtonViewGradient = UIView()
+    lazy var bottomButtonView: BottomButtonView = BottomButtonView(
+        primaryButtonText: "으악",
+        lineButtonText: "찾는 대학교가 없어요. 우선 둘러볼게요!",
+        primaryButtonHandler: bottomButtonPrimaryHandler,
+        lineButtonHandler: bottomButtonLineHandler
+    )
     
     private lazy var univCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: setupUnivCollectionViewFlowLayout())
     
@@ -33,15 +34,8 @@ final class UnivSelectViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        setupButtonAction()
         setupDelegate()
         setupRegister()
-    }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        setupBottomButtonViewGradient()
     }
     
     override func setupStyle() {
@@ -73,41 +67,15 @@ final class UnivSelectViewController: BaseViewController {
         univCollectionView.do {
             $0.allowsMultipleSelection = false
         }
-        
-        bottomButtonView.do {
-            $0.backgroundColor = .clear
-        }
-        
-        doneButton.do {
-            if let attributedTitle = UILabel.setupAttributedText(
-                for: PretendardStyle.subtitle3,
-                withText: "선택하기",
-                color: .hankkiWhite
-            ) {
-                $0.setAttributedTitle(attributedTitle, for: .normal)
-            }
-            $0.backgroundColor = .hankkiRedLight2
-            $0.layer.cornerRadius = 16
-            $0.isEnabled = false
-        }
-        
-        laterButton.do {
-            $0.setTitle("찾는 대학교가 없어요. 우선 둘러볼게요!", for: .normal)
-            $0.titleLabel?.font = .setupPretendardStyle(of: .button)
-            $0.setTitleColor(.gray400, for: .normal)
-            $0.setUnderline()
-        }
     }
     
     override func setupHierarchy() {
         view.addSubviews(
             headerStackView,
             univCollectionView,
-            bottomButtonViewGradient, 
             bottomButtonView
         )
         headerStackView.addArrangedSubviews(headerTitleLabel, headerContentLabel)
-        bottomButtonView.addSubviews(doneButton, laterButton)
     }
     
     override func setupLayout() {
@@ -121,25 +89,10 @@ final class UnivSelectViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview()
         }
         
-        bottomButtonViewGradient.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
-            $0.height.equalTo(154)
-        }
-        
         bottomButtonView.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
-        }
-        
-        doneButton.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview().inset(50)
-            $0.leading.trailing.equalToSuperview().inset(22)
-            $0.height.equalTo(54)
-        }
-        
-        laterButton.snp.makeConstraints {
-            $0.top.equalTo(doneButton.snp.bottom).offset(14)
-            $0.centerX.equalToSuperview()
-            $0.height.equalTo(18)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(154)
         }
     }
 }
@@ -160,47 +113,13 @@ private extension UnivSelectViewController {
         return layout
     }
     
-    func setupEnabledDoneButton() {
-        doneButton.do {
-            $0.backgroundColor = .hankkiRed
-            $0.isEnabled = true
-        }
+    // Todo: - 나중에 수정
+    func bottomButtonPrimaryHandler() {
+        print(currentUniv, "을 선택했어요!")
     }
     
-    func setupBottomButtonViewGradient() {
-        let gradient = CAGradientLayer()
-        
-        gradient.do {
-            $0.colors = [
-                UIColor.white.withAlphaComponent(0).cgColor,
-                UIColor.white.cgColor,
-                UIColor.white.cgColor
-              ]
-            $0.locations = [0.0, 0.3, 1.0]
-            $0.startPoint = CGPoint(x: 0.5, y: 0.0)
-            $0.endPoint = CGPoint(x: 0.5, y: 1.0)
-            $0.frame = bottomButtonView.bounds
-            
-        }
-        
-        bottomButtonViewGradient.layer.addSublayer(gradient)
-    }
-    
-    // MARK: - @objc
-    
-    @objc func doneButtonDidTap() {
-        // TODO: - api 연동 후 버튼 내용 수정
-        print(currentUniv, ": 선택하기 버튼이 클릭되었습니다.")
-    }
-    
-    @objc func laterButtonDidTap() {
-        // TODO: - api 연동 후 버튼 내용 수정
-        print("찾는대학이 없는 버튼이 클릭되었습니다.")
-    }
-    
-    func setupButtonAction() {
-        doneButton.addTarget(self, action: #selector(doneButtonDidTap), for: .touchUpInside)
-        laterButton.addTarget(self, action: #selector(laterButtonDidTap), for: .touchUpInside)
+    func bottomButtonLineHandler() {
+        print("지금 선택하지 않았어요")
     }
     
     func setupRegister() {
@@ -232,9 +151,9 @@ extension UnivSelectViewController: UICollectionViewDataSource {
 
 extension UnivSelectViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        currentUniv = dummyUnivList[indexPath[1]]
+        currentUniv = dummyUnivList[indexPath.item]
         if !currentUniv.isEmpty {
-            setupEnabledDoneButton()
+            bottomButtonView.setupEnabledDoneButton()
         }
     }
 }


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- Botton Button 을 컴포넌트화 했습니다.

## 🖥️ 주요 코드 설명
- **선언하는 방법**
```swift 
    lazy var bottomButtonView: BottomButtonView = BottomButtonView(
        primaryButtonText: "으악",
        lineButtonText: "찾는 대학교가 없어요. 우선 둘러볼게요!",
        primaryButtonHandler: bottomButtonPrimaryHandler,
        lineButtonHandler: bottomButtonLineHandler
    )
```
primaryButtonText : 빨간 버튼에 들어갈 텍스트
lineButtonText: 밑줄 버튼에 들어갈 텍스트 (값을 작성하지 않을시 보이지 않습니다.)
primaryButtonHandler, lineButtonHandler: 버튼 동작 함수 입력

- **하단에 넣는 방법**
```swift
//primaryButton일때 
        bottomButtonView.snp.makeConstraints {
            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
            $0.height.equalTo(154)
        }
//lineButton 일때
        bottomButtonView.snp.makeConstraints {
            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(34)
            $0.height.equalTo(154)
        }
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #37
