### PR TITLE
[Network] #79 - 식당 제보수 조회 API 연동

### DIFF
--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		A2EC33D12C47938A00809840 /* ReportCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2EC33CE2C47938A00809840 /* ReportCompleteViewController.swift */; };
 		A2EC33D52C47939500809840 /* HankkiInfoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2EC33D22C47939500809840 /* HankkiInfoCardView.swift */; };
 		A2EC33D62C47939500809840 /* ReportCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2EC33D32C47939500809840 /* ReportCompleteViewController.swift */; };
+		A2EC33D92C47CFA500809840 /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2EC33D82C47CFA500809840 /* ReportViewModel.swift */; };
 		A2F27BE32C34EED1001E6514 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = A2B5423D2C32A29300A6B225 /* Pretendard-Bold.otf */; };
 		A2F27BE42C34EED4001E6514 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = A2B5423C2C32A29300A6B225 /* Pretendard-SemiBold.otf */; };
 		A2F27BE52C34EED6001E6514 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = A2B5423F2C32A29400A6B225 /* Pretendard-Medium.otf */; };
@@ -292,6 +293,7 @@
 		A2EC33CE2C47938A00809840 /* ReportCompleteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportCompleteViewController.swift; sourceTree = "<group>"; };
 		A2EC33D22C47939500809840 /* HankkiInfoCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HankkiInfoCardView.swift; sourceTree = "<group>"; };
 		A2EC33D32C47939500809840 /* ReportCompleteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportCompleteViewController.swift; sourceTree = "<group>"; };
+		A2EC33D82C47CFA500809840 /* ReportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewModel.swift; sourceTree = "<group>"; };
 		A2F27BFB2C3500DB001E6514 /* SUITE-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUITE-SemiBold.otf"; sourceTree = "<group>"; };
 		A2F27BFC2C3500DB001E6514 /* SUITE-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUITE-Bold.otf"; sourceTree = "<group>"; };
 		A2F27BFD2C3500DB001E6514 /* SUITE-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUITE-Regular.otf"; sourceTree = "<group>"; };
@@ -855,6 +857,7 @@
 		A240EA112C3F19F4000FF458 /* ReportMain */ = {
 			isa = PBXGroup;
 			children = (
+				A2EC33D72C47CF6000809840 /* ViewModel */,
 				A2DEBF582C3D257C00DE14A9 /* View */,
 			);
 			path = ReportMain;
@@ -1089,6 +1092,14 @@
 			path = Complete;
 			sourceTree = "<group>";
 		};
+		A2EC33D72C47CF6000809840 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				A2EC33D82C47CFA500809840 /* ReportViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1313,6 +1324,7 @@
 				83DBED782C255A180042BA48 /* SceneDelegate.swift in Sources */,
 				864FA9082C3D20560051EA36 /* MypageHeaderView.swift in Sources */,
 				83DBEDCE2C256B180042BA48 /* UIButton+.swift in Sources */,
+				A2EC33D92C47CFA500809840 /* ReportViewModel.swift in Sources */,
 				A2EC33C42C47183700809840 /* GetReportedNumberResponseDTO.swift in Sources */,
 				83DBEDB92C25666E0042BA48 /* MainButton.swift in Sources */,
 				83DA28962C3851BB004819FA /* HankkiNavigationType.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkService.swift
@@ -20,4 +20,5 @@ final class NetworkService {
 //    let universityService: UniversityAPIServiceProtocol = UniversityAPIService()
 //    let locationService: LocationAPIServiceProtocol = LocationAPIService()
 //    let favoriteService: FavoriteAPIServiceProtocol = FavoriteAPIServie()
+    let reportService: ReportAPIServiceProtocol = ReportAPIService()
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Report/DTO/Response/GetReportedNumberResponseDTO.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Report/DTO/Response/GetReportedNumberResponseDTO.swift
@@ -9,12 +9,6 @@ import Foundation
 
 // MARK: - 제보수 조회 API Res
 
-struct GetReportedNumberResponseDTO: Codable {
-    var code: Int
-    var message: String
-    var data: GetReportedNumberResponseData
-}
-
 struct GetReportedNumberResponseData: Codable {
     var count: Int64
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Report/ReportAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Report/ReportAPIService.swift
@@ -10,11 +10,15 @@ import Foundation
 import Moya
 
 protocol ReportAPIServiceProtocol {
+    typealias GetReportedNumberResponseDTO = BaseDTO<GetReportedNumberResponseData>
     func getReportedNumber(completion: @escaping(NetworkResult<GetReportedNumberResponseDTO>) -> Void)
 }
 
 final class ReportAPIService: BaseAPIService, ReportAPIServiceProtocol {
+    
     private let provider = MoyaProvider<ReportTargetType>(plugins: [MoyaPlugin()])
+    
+    
     func getReportedNumber(completion: @escaping (NetworkResult<GetReportedNumberResponseDTO>) -> Void) {
         provider.request(.getReportedNumber) { result in
             switch result {

--- a/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/ReportViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/ReportViewController.swift
@@ -17,6 +17,8 @@ final class ReportViewController: BaseViewController {
     
     // MARK: - Properties
     
+    var viewModel: ReportViewModel = ReportViewModel()
+    
     var isImageSet: Bool = false
     var image: UIImage?
     
@@ -49,6 +51,9 @@ final class ReportViewController: BaseViewController {
         
         setupRegister()
         setupDelegate()
+        bindViewModel()
+        
+        viewModel.getReportedNumber()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -89,6 +94,15 @@ final class ReportViewController: BaseViewController {
         collectionView.do {
             $0.backgroundColor = .hankkiWhite
             $0.showsVerticalScrollIndicator = false
+        }
+    }
+}
+
+extension ReportViewController {
+    
+    func bindViewModel() {
+        viewModel.updateReportedNumber = {
+            self.collectionView.reloadItems(at: [IndexPath(item: 0, section: 0)])
         }
     }
 }
@@ -249,6 +263,7 @@ extension ReportViewController: UICollectionViewDataSource, UICollectionViewDele
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchBarCollectionViewCell.className, for: indexPath) as? SearchBarCollectionViewCell else { return UICollectionViewCell() }
             cell.hankkiNameString = self.hankkiNameString ?? ""
             cell.searchBarButton.addTarget(self, action: #selector(searchBarButtonDidTap), for: .touchUpInside)
+            cell.bindGuideText(text: viewModel.reportedNumberGuideText)
             return cell
         case .category:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.className, for: indexPath) as? CategoryCollectionViewCell else { return UICollectionViewCell() }

--- a/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/SearchBarCollectionViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/SearchBarCollectionViewCell.swift
@@ -11,6 +11,17 @@ final class SearchBarCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - Properties
     
+    var reportedNumberText: String = "" {
+        didSet {
+            reportedNumberLabel.do {
+                $0.attributedText = UILabel.setupAttributedText(
+                    for: PretendardStyle.body4,
+                    withText: reportedNumberText,
+                    color: .hankkiRed
+                )
+            }
+        }
+    }
     var hankkiNameString: String = "" {
         didSet {
             if hankkiNameString != "" {
@@ -56,13 +67,6 @@ final class SearchBarCollectionViewCell: BaseCollectionViewCell {
     }
     
     override func setupStyle() {
-        reportedNumberLabel.do {
-            $0.attributedText = UILabel.setupAttributedText(
-                for: PretendardStyle.body4,
-                withText: "52번째 제보예요",
-                color: .hankkiRed
-            )
-        }
         descriptionLabel.do {
             $0.attributedText = UILabel.setupAttributedText(
                 for: SuiteStyle.h3,
@@ -123,5 +127,11 @@ final class SearchBarCollectionViewCell: BaseCollectionViewCell {
             $0.configuration?.contentInsets = .init(top: 0, leading: 14, bottom: 0, trailing: 14)
             $0.configuration?.imagePadding = 4
         }
+    }
+}
+
+extension SearchBarCollectionViewCell {
+    func bindGuideText(text: String) {
+        self.reportedNumberText = text
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/ViewModel/ReportViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/ViewModel/ReportViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  ReportViewModel.swift
+//  Hankkijogbo
+//
+//  Created by 서은수 on 7/17/24.
+//
+
+import Foundation
+
+import Moya
+
+final class ReportViewModel {
+    private let reportAPIService: ReportAPIServiceProtocol
+
+    var reportedNumberGuideText: String = "" {
+        didSet {
+            updateReportedNumber?()
+        }
+    }
+    var updateReportedNumber: (() -> Void)?
+    
+    init(reportAPIService: ReportAPIServiceProtocol = ReportAPIService()) {
+        self.reportAPIService = reportAPIService
+    }
+
+    func getReportedNumber() {
+        NetworkService.shared.reportService.getReportedNumber { [weak self] result in
+            switch result {
+            case .success(let response):
+                guard let count = response?.data.count else { return }
+                self?.reportedNumberGuideText = "\(count)번째 제보예요"
+            case .badRequest, .unAuthorized:
+                // TODO: - 에러 상황에 공통적으로 띄워줄만한 Alert나 Toast가 있어야 하지 않을까?
+                print("badRequest")
+            case .serverError:
+                print("serverError")
+            default:
+                return
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- BaseDTO 적용
- 제보수 조회 API 연동 및 데이터 바인딩

## 📸 스크린샷
<img width="428" alt="스크린샷 2024-07-17 오후 9 55 56" src="https://github.com/user-attachments/assets/11f515fa-92e4-4284-9ef9-73f95cffc6c5">  

|    구현 내용    |   SE   | 
| :-------------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/70fece04-c2c8-4acc-869e-4deebcf1a628" width ="250"> | 

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`HomeView`
- typealias를 사용하여 BaseDTO<T> 형태의 가독성을 높이고자 하였습니다.
```swift
protocol ReportAPIServiceProtocol {
    typealias GetReportedNumberResponseDTO = BaseDTO<GetReportedNumberResponseData>
    func getReportedNumber(completion: @escaping(NetworkResult<GetReportedNumberResponseDTO>) -> Void)
}
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #79 
