### PR TITLE
[Network] #155 - Login View 로직 수정, Refresh Token 로직추가

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
@@ -35,4 +35,3 @@ extension UIApplication {
         }
     }
 }
-

--- a/Hankkijogbo/Hankkijogbo/Network/Auth/AuthAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Auth/AuthAPIService.swift
@@ -74,6 +74,7 @@ final class AuthAPIService: BaseAPIService, AuthAPIServiceProtocol {
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<PostReissueResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                completion(networkResult)
             case .failure(let error):
                 if let response = error.response {
                     let networkResult: NetworkResult<PostReissueResponseData> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)

--- a/Hankkijogbo/Hankkijogbo/Network/Auth/AuthAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Auth/AuthAPIService.swift
@@ -15,8 +15,8 @@ protocol AuthAPIServiceProtocol {
     
     func postLogin(accessToken: String, requestBody: PostLoginRequestDTO, completion: @escaping(NetworkResult<PostLoginResponseDTO>) -> Void)
     func patchLogout(completion: @escaping(NetworkResult<EmptyDTO>) -> Void)
-    func deleteWithdraw(authorizationCode: String, completion: @escaping(NetworkResult<EmptyDTO>) -> Void)
-    func postReissue(completion: @escaping(NetworkResult<PostReissueResponseDTO>) -> Void)
+    func deleteWithdraw(authorizationCode: String, completion: @escaping(NetworkResult<Void>) -> Void)
+    func postReissue(completion: @escaping (NetworkResult<PostReissueResponseDTO>) -> Void)
 }
 
 final class AuthAPIService: BaseAPIService, AuthAPIServiceProtocol {
@@ -54,15 +54,15 @@ final class AuthAPIService: BaseAPIService, AuthAPIServiceProtocol {
         }
     }
     
-    func deleteWithdraw(authorizationCode: String, completion: @escaping (NetworkResult<EmptyDTO>) -> Void) {
+    func deleteWithdraw(authorizationCode: String, completion: @escaping (NetworkResult<Void>) -> Void) {
         provider.request(.deleteWithdraw(authorizationCode: authorizationCode)) { result in
             switch result {
             case .success(let response):
-                let networkResult: NetworkResult<EmptyDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                let networkResult: NetworkResult<Void> = self.fetchNetworkResult(statusCode: response.statusCode)
                 completion(networkResult)
             case .failure(let error):
                 if let response = error.response {
-                    let networkResult: NetworkResult<EmptyDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    let networkResult: NetworkResult<Void> = self.fetchNetworkResult(statusCode: response.statusCode)
                     completion(networkResult)
                 }
             }
@@ -77,7 +77,8 @@ final class AuthAPIService: BaseAPIService, AuthAPIServiceProtocol {
                 completion(networkResult)
             case .failure(let error):
                 if let response = error.response {
-                    let networkResult: NetworkResult<PostReissueResponseData> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    let networkResult: NetworkResult<PostReissueResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    completion(networkResult)
                 }
             }
         }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/BaseAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/BaseAPIService.swift
@@ -12,10 +12,12 @@ class BaseAPIService {
     /// 200 받았을 때 decoding 할 데이터가 있는 경우 (대부분의 GET)
     func fetchNetworkResult<T: Decodable>(statusCode: Int, data: Data) -> NetworkResult<T> {
         switch statusCode {
-        case 200, 201, 204:
+        case 200, 201:
             if let decodedData = fetchDecodeData(data: data, responseType: T.self) {
                 return .success(decodedData)
             } else { return .decodeError }
+        case 204: return .success(nil)
+            
         case 400: return .badRequest
         case 401: return .unAuthorized
         case 404: return .notFound
@@ -26,7 +28,7 @@ class BaseAPIService {
     }
     
     /// 200 받았을 때 decoding 할 데이터가 없는 경우 (대부분의 PATCH, PUT, DELETE)
-    func fetchNetworkResult(statusCode: Int, data: Data) -> NetworkResult<Any> {
+    func fetchNetworkResult(statusCode: Int) -> NetworkResult<Void> {
         switch statusCode {
         case 200, 201, 204: return .success(nil)
         case 400: return .badRequest

--- a/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
@@ -61,20 +61,29 @@ extension BaseTargetType {
         case .loginHeader(let accessToken):
             header["Content-Type"] = "application/json"
             header["Authorization"] = "\(accessToken)"
+            
         case .withdrawHeader(let authorizationCode):
             header["Content-Type"] = "application/json"
             let accessToken = UserDefaults.standard.getAccesshToken()
             header["Authorization"] = URLConstant.bearer + "\(accessToken)"
             header["X-Apple-Code"] = "\(authorizationCode)"
+            
+        case .refreshTokenHeader:
+            header["Content-Type"] = "application/json"
+            let refreshToken = UserDefaults.standard.getRefreshToken()
+            header["Authorization"] = URLConstant.bearer + "\(refreshToken)"
+            
         case .formdataHeader:
             header["Content-Type"] = "multipart/form-data"
             let accessToken = UserDefaults.standard.getAccesshToken()
             header["Authorization"] = URLConstant.bearer + "\(accessToken)"
+            
         default:
             header["Content-Type"] = "application/json"
             let accessToken = UserDefaults.standard.getAccesshToken()
             header["Authorization"] = URLConstant.bearer + "\(accessToken)"
         }
+        
         return header
     }
     

--- a/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
@@ -33,7 +33,7 @@ final class MoyaPlugin: PluginType {
         if let body = httpRequest.httpBody, let bodyString = String(bytes: body, encoding: String.Encoding.utf8) {
             log.append("✏️ body:\n\(bodyString)\n")
         }
-        log.append("=======================================================\n\n")
+        log.append("=======================================================\n")
         print(log)
     }
 
@@ -59,7 +59,7 @@ final class MoyaPlugin: PluginType {
         if let reString = String(bytes: response.data, encoding: String.Encoding.utf8) {
             log.append("\n4️⃣ \(reString)\n")
         }
-        log.append("=======================================================\n\n")
+        log.append("=======================================================\n")
         print(log)
     }
 

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
@@ -45,7 +45,6 @@ extension NetworkResult {
         switch result {
         case .success(let response):
             if let res = response {
-                print(1)
                 onSuccess?(res)
             } else if T.self == Void.self {
                 onSuccessVoid?()

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
@@ -41,13 +41,16 @@ enum NetworkResult<T> {
 }
 
 extension NetworkResult {
-    func handleNetworkResult(_ result: NetworkResult, onSuccess: ((T) -> Void)? = nil) {
+    func handleNetworkResult(_ result: NetworkResult, onSuccess: ((T) -> Void)? = nil, onSuccessVoid: (() -> Void)? = nil) {
         switch result {
         case .success(let response):
             if let res = response {
+                print(1)
                 onSuccess?(res)
+            } else if T.self == Void.self {
+                onSuccessVoid?()
             } else {
-                print(result)
+                print("🚨 RESPONSE IS NIL 🚨")
             }
             
         case .unAuthorized:

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
@@ -51,8 +51,9 @@ extension NetworkResult {
             }
             
         case .unAuthorized:
-            //TODO: - 리프레쉬 토큰 재발급 하기
-            print("Get Refresh Token")
+            // 401 error
+            // access token이 올바르지 않거나, 만료된 경우
+            self.postReissue()
             
         default:
             // TODO: - 상세한 분기처리 필요 (기디 논의 필요)
@@ -63,6 +64,21 @@ extension NetworkResult {
                 rootViewController.showAlert(titleText: "오류 발생",
                                              subText: result.stateDescription,
                                              primaryButtonText: "확인")
+            }
+        }
+    }
+}
+
+private extension NetworkResult {
+    func postReissue() {
+        NetworkService.shared.authService.postReissue { result in
+            switch result {
+            case .success(let response):
+                UserDefaults.standard.saveTokens(accessToken: response?.data.accessToken ?? "",
+                                                 refreshToken: response?.data.refreshToken ?? "")
+            default:
+                print("🛠️ RESET APPLICATION 🛠️\n\n")
+                UIApplication.resetApp()
             }
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Network/Zip/ZipAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Zip/ZipAPIService.swift
@@ -17,7 +17,7 @@ protocol ZipAPIServiceProtocol {
     func getZipList(zipId: Int, completion: @escaping(NetworkResult<GetZipDetailResponseDTO>) -> Void)
     func postZipBatchDelete(requesBody: PostZipBatchDeleteRequestDTO, completion: @escaping(NetworkResult<Void>) -> Void)
     func postZip(requestBody: PostZipRequestDTO, completion: @escaping (NetworkResult<EmptyDTO>) -> Void)
-    func deleteZipToHankki(requestBody: DeleteZipToHankkiRequestDTO, completion: @escaping (NetworkResult<EmptyDTO>) -> Void)
+    func deleteZipToHankki(requestBody: DeleteZipToHankkiRequestDTO, completion: @escaping (NetworkResult<Void>) -> Void)
     func postHankkiToZip(requestBody: PostHankkiToZipRequestDTO, completion: @escaping(NetworkResult<EmptyDTO>) -> Void)
 }
 
@@ -25,15 +25,15 @@ final class ZipAPIService: BaseAPIService, ZipAPIServiceProtocol {
     
     private let provider = MoyaProvider<ZipTargetType>(plugins: [MoyaPlugin()])
     
-    func deleteZipToHankki(requestBody: DeleteZipToHankkiRequestDTO, completion: @escaping (NetworkResult<EmptyDTO>) -> Void) {
+    func deleteZipToHankki(requestBody: DeleteZipToHankkiRequestDTO, completion: @escaping (NetworkResult<Void>) -> Void) {
         provider.request(.deleteZipToHankki(requestBody: requestBody)) { result in
             switch result {
             case .success(let response):
-                let networkResult: NetworkResult<EmptyDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                let networkResult: NetworkResult<Void> = self.fetchNetworkResult(statusCode: response.statusCode)
                 completion(networkResult)
             case .failure(let error):
                 if let response = error.response {
-                    let networkResult: NetworkResult<EmptyDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    let networkResult: NetworkResult<Void> = self.fetchNetworkResult(statusCode: response.statusCode)
                     completion(networkResult)
                 }
             }
@@ -50,6 +50,7 @@ final class ZipAPIService: BaseAPIService, ZipAPIServiceProtocol {
             case .failure(let error):
                 if let response = error.response {
                     let networkResult: NetworkResult<GetMyZipListResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    completion(networkResult)
                 }
             }
         }

--- a/Hankkijogbo/Hankkijogbo/Network/Zip/ZipAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Zip/ZipAPIService.swift
@@ -15,7 +15,7 @@ protocol ZipAPIServiceProtocol {
     
     func getMyZipList(id: Int64, completion: @escaping(NetworkResult<GetMyZipListResponseDTO>) -> Void)
     func getZipList(zipId: Int, completion: @escaping(NetworkResult<GetZipDetailResponseDTO>) -> Void)
-    func postZipBatchDelete(requesBody: PostZipBatchDeleteRequestDTO, completion: @escaping(NetworkResult<EmptyDTO>) -> Void)
+    func postZipBatchDelete(requesBody: PostZipBatchDeleteRequestDTO, completion: @escaping(NetworkResult<Void>) -> Void)
     func postZip(requestBody: PostZipRequestDTO, completion: @escaping (NetworkResult<EmptyDTO>) -> Void)
     func deleteZipToHankki(requestBody: DeleteZipToHankkiRequestDTO, completion: @escaping (NetworkResult<EmptyDTO>) -> Void)
     func postHankkiToZip(requestBody: PostHankkiToZipRequestDTO, completion: @escaping(NetworkResult<EmptyDTO>) -> Void)
@@ -70,16 +70,15 @@ final class ZipAPIService: BaseAPIService, ZipAPIServiceProtocol {
         }
     }
     
-    func postZipBatchDelete(requesBody: PostZipBatchDeleteRequestDTO, completion: @escaping (NetworkResult<EmptyDTO>) -> Void) {
+    func postZipBatchDelete(requesBody: PostZipBatchDeleteRequestDTO, completion: @escaping (NetworkResult<Void>) -> Void) {
         provider.request(.postZipBatchDelete(requestBody: requesBody)) { result in
-            
             switch result {
             case .success(let response):
-                let networkResult: NetworkResult<EmptyDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                let networkResult: NetworkResult<Void> = self.fetchNetworkResult(statusCode: response.statusCode)
                 completion(networkResult)
             case .failure(let error):
                 if let response = error.response {
-                    let networkResult: NetworkResult<EmptyDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    let networkResult: NetworkResult<Void> = self.fetchNetworkResult(statusCode: response.statusCode)
                     completion(networkResult)
                 }
             }

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -188,7 +188,7 @@ private extension CreateZipViewController {
     func submitButtonDidTap() {
         let arr = (tagInputTextField.text ?? "").split(separator: " ").map { String($0) }
         let data = PostZipRequestDTO(title: titleInputTextField.text ?? " ", details: arr)
-        print(arr, data)
+
         viewModel.postZip(data)
     }
     

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/Cell/HankkiListTableViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/Cell/HankkiListTableViewCell.swift
@@ -160,7 +160,6 @@ final class HankkiListTableViewCell: BaseTableViewCell {
 
 extension HankkiListTableViewCell {
     func dataBind(_ data: DataStruct, isLikeButtonDisable: Bool) {
-        print(data.name)
         self.data = data
 
         titleLabel.text = data.name

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/Cell/ZipHeaderTableView.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/Cell/ZipHeaderTableView.swift
@@ -146,8 +146,7 @@ final class ZipHeaderTableView: UITableViewHeaderFooterView {
 
 private extension ZipHeaderTableView {
     @objc func shareButtonDidTap() {
-        print("print")
-//        self.showAlert?("Failed")
+        // TODO: - 공유 로직 추가 필요
     }
     
     func setupAddTarget() {

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/HankkiListViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/HankkiListViewController.swift
@@ -46,9 +46,9 @@ final class  HankkiListViewController: BaseViewController {
         bindViewModel()
         
         if type == .myZip {
-            viewModel.getZipDetail(zipId: zipId ?? 0, completion: {_ in})
+            viewModel.getZipDetail(zipId: zipId ?? 0)
         } else {
-            viewModel.getMeHankkiList(type.userTargetType, completion: {_ in})
+            viewModel.getMeHankkiList(type.userTargetType)
         }
     }
     
@@ -195,11 +195,11 @@ extension HankkiListViewController: UITableViewDataSource {
     }
     
     func deleteLike(_ id: Int64) {
-        viewModel.deleteHankkiHeartAPI(id: id) {}
+        viewModel.deleteHankkiHeart(id: id)
     }
     
     func postLike(_ id: Int64) {
-        viewModel.postHankkiHeartAPI(id: id) {}
+        viewModel.postHankkiHeart(id: id)
     }
 }
 

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/HankkiListViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/HankkiListViewController.swift
@@ -276,7 +276,12 @@ private extension HankkiListViewController {
     /// 셀을 지우는 함수
     func deleteItem(at indexPath: IndexPath) {
         let request: DeleteZipToHankkiRequestDTO = DeleteZipToHankkiRequestDTO(favoriteId: zipId ?? 0, storeId: viewModel.hankkiList[indexPath.item].id)
-        viewModel.deleteZipToHankki(requestBody: request, completion: {_ in})
+        viewModel.deleteZipToHankki(requestBody: request) {
+            self.removeCellFromCollectionView(indexPath)
+        }
+    }
+    
+    private func removeCellFromCollectionView(_ indexPath: IndexPath) {
         viewModel.hankkiList.remove(at: indexPath.row)
         
         hankkiTableView.beginUpdates()

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/ViewModel/HankkiListViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/ViewModel/HankkiListViewModel.swift
@@ -98,16 +98,9 @@ extension HankkiListViewModel {
         }
     }
     
-    func deleteZipToHankki(requestBody: DeleteZipToHankkiRequestDTO, completion: @escaping (Bool) -> Void) {
+    func deleteZipToHankki(requestBody: DeleteZipToHankkiRequestDTO, completion: @escaping () -> Void) {
         NetworkService.shared.zipService.deleteZipToHankki(requestBody: requestBody) { result in
-            switch result {
-            case .success(_): return
-            case .unAuthorized, .pathError:
-                self.showAlert?("Failed")
-            default:
-                return
-                
-            }
+            result.handleNetworkResult(result, onSuccessVoid: completion)
         }
     }
     

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/ViewModel/HankkiListViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/ViewModel/HankkiListViewModel.swift
@@ -30,70 +30,45 @@ final class HankkiListViewModel {
 extension HankkiListViewModel {
     func getMe() {
         NetworkService.shared.userService.getMe { result in
-            switch result {
-            case .success(let response):
-                if let responseData = response {
-                    self.name = responseData.data.nickname
-                    self.imageUrl = responseData.data.profileImageUrl
-                } else { return }
-            case .unAuthorized, .pathError:
-                self.showAlert?("Failed")
-            default:
-                return
+            result.handleNetworkResult(result) { response in
+                self.name = response.data.nickname
+                self.imageUrl = response.data.profileImageUrl
             }
         }
     }
     
-    func getZipDetail(zipId: Int, completion: @escaping(Bool) -> Void) {
+    func getZipDetail(zipId: Int) {
         NetworkService.shared.zipService.getZipList(zipId: zipId) { result in
-            switch result {
-            case .success(let response):
-                if let responseData = response {
-                    self.zipInfo = ZipHeaderTableView.DataStruct(name: self.name ?? "",
-                                                                 imageUrl: self.imageUrl ?? "",
-                                                                 title: responseData.data.title,
-                                                                 details: responseData.data.details)
-                    
-                    self.hankkiList = responseData.data.stores.map {
-                        return HankkiListTableViewCell.DataStruct(id: $0.id,
-                                                                  name: $0.name,
-                                                                  imageURL: $0.imageUrl,
-                                                                  category: $0.category,
-                                                                  lowestPrice: $0.lowestPrice,
-                                                                  heartCount: $0.heartCount)
-                    }
-                } else { print("Error") }
-                completion(true)
-            case .unAuthorized, .networkFail:
-                self.showAlert?("Failed")
-                completion(false)
-            default:
-                return
+            
+            result.handleNetworkResult(result) { response in
+                self.zipInfo = ZipHeaderTableView.DataStruct(name: self.name ?? "",
+                                                             imageUrl: self.imageUrl ?? "",
+                                                             title: response.data.title,
+                                                             details: response.data.details)
+                
+                self.hankkiList = response.data.stores.map {
+                    return HankkiListTableViewCell.DataStruct(id: $0.id,
+                                                              name: $0.name,
+                                                              imageURL: $0.imageUrl,
+                                                              category: $0.category,
+                                                              lowestPrice: $0.lowestPrice,
+                                                              heartCount: $0.heartCount)
+                }
             }
         }
     }
     
-    func getMeHankkiList(_ type: UserTargetType, completion: @escaping (Bool) -> Void) {
+    func getMeHankkiList(_ type: UserTargetType) {
         NetworkService.shared.userService.getMeHankkiList(type) { result in
-            switch result {
-            case .success(let response):
-                if let responseData = response {
-                    self.hankkiList = responseData.data.stores.map {
-                        return HankkiListTableViewCell.DataStruct(id: $0.id,
-                                                                  name: $0.name,
-                                                                  imageURL: $0.imageUrl,
-                                                                  category: $0.category,
-                                                                  lowestPrice: $0.lowestPrice,
-                                                                  heartCount: $0.heartCount)
-                    }
-                } else { print("오류 발생") }
-                completion(true)
-            case .unAuthorized, .networkFail:
-                self.showAlert?("Failed")
-                print("Failed to fetch university list.")
-                completion(false)
-            default:
-                return
+            result.handleNetworkResult(result) { response in
+                self.hankkiList = response.data.stores.map {
+                    return HankkiListTableViewCell.DataStruct(id: $0.id,
+                                                              name: $0.name,
+                                                              imageURL: $0.imageUrl,
+                                                              category: $0.category,
+                                                              lowestPrice: $0.lowestPrice,
+                                                              heartCount: $0.heartCount)
+                }
             }
         }
     }
@@ -104,27 +79,15 @@ extension HankkiListViewModel {
         }
     }
     
-    func postHankkiHeartAPI(id: Int64, completion: @escaping () -> Void) {
+    func postHankkiHeart(id: Int64) {
         NetworkService.shared.hankkiService.postHankkiHeart(id: id) { result in
-            switch result {
-            case .success(_): return
-            case .unAuthorized, .networkFail:
-                self.showAlert?("Failed")
-            default:
-                return
-            }
+            result.handleNetworkResult(result)
         }
     }
     
-    func deleteHankkiHeartAPI(id: Int64, completion: @escaping () -> Void) {
+    func deleteHankkiHeart(id: Int64) {
         NetworkService.shared.hankkiService.deleteHankkiHeart(id: id) { result in
-            switch result {
-            case .success(_): return
-            case .unAuthorized, .networkFail:
-                self.showAlert?("Failed")
-            default:
-                return
-            }
+            result.handleNetworkResult(result) 
         }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Login/View/LoginViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Login/View/LoginViewController.swift
@@ -142,9 +142,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
     }
     
     // 실패 후 동작
-    func authorizationController(
-        controller: ASAuthorizationController,
-        didCompleteWithError error: Error) {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         print("애플 로그인 실패: \(error.localizedDescription)")
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Login/ViewModel/LoginViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Login/ViewModel/LoginViewModel.swift
@@ -11,6 +11,27 @@ import UIKit
 final class LoginViewModel { }
 
 extension LoginViewModel {
+    func getUniversity() {
+        UserDefaults.standard.removeUniversity()
+        
+        NetworkService.shared.userService.getMeUniversity { result in
+            result.handleNetworkResult(result) { response in
+                let university: UniversityModel = UniversityModel(id: response.data.id,
+                                                                  name: response.data.name,
+                                                                  longitude: response.data.longitude,
+                                                                  latitude: response.data.latitude)
+                UserDefaults.standard.saveUniversity(university)
+
+                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                    if let window = windowScene.windows.first {
+                        let navigationController = HankkiNavigationController(rootViewController: TabBarController())
+                        window.rootViewController = navigationController
+                    }
+                }
+            }
+        }
+    }
+    
     func postLogin (accessToken: String, postLoginRequest: PostLoginRequestDTO) {
         NetworkService.shared.authService.postLogin(accessToken: accessToken, requestBody: postLoginRequest) { result in
             result.handleNetworkResult(result) { response in
@@ -24,12 +45,14 @@ extension LoginViewModel {
                         if let window = windowScene.windows.first {
                             if response.data.isRegistered {
                                 // isRegistered -> true ( 로그인 )
-                                // -> 홈 뷰로 넘어감
-                                let navigationController = HankkiNavigationController(rootViewController: TabBarController())
-                                window.rootViewController = navigationController
+                                // -> 사용자의 대학정보 가져오기
+                                // -> 홈 뷰로 이동
+                                self.getUniversity()
                             } else {
                                 // isRegistered -> false ( 회원가입 )
-                                // -> 대학 선택 뷰로 넘어감
+                                // -> 온보딩 뷰로 넘어감
+                                window.rootViewController = OnboardingViewController()
+                                
                                 let navigationController = HankkiNavigationController(rootViewController: TabBarController())
                                 window.rootViewController = navigationController
                                 navigationController.pushViewController(UnivSelectViewController(), animated: false)

--- a/Hankkijogbo/Hankkijogbo/Present/Login/ViewModel/LoginViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Login/ViewModel/LoginViewModel.swift
@@ -52,10 +52,6 @@ extension LoginViewModel {
                                 // isRegistered -> false ( 회원가입 )
                                 // -> 온보딩 뷰로 넘어감
                                 window.rootViewController = OnboardingViewController()
-                                
-                                let navigationController = HankkiNavigationController(rootViewController: TabBarController())
-                                window.rootViewController = navigationController
-                                navigationController.pushViewController(UnivSelectViewController(), animated: false)
                             }
                         }
                     }

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/ViewModel/MypageViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/ViewModel/MypageViewModel.swift
@@ -31,7 +31,8 @@ extension MypageViewModel {
     
     func patchLogout() {
         NetworkService.shared.authService.patchLogout { result in
-           result.handleNetworkResult(result) { response in
+           result.handleNetworkResult(result) { _ in
+               print("🛠️ RESTART APPLICATION 🛠️ - LOGOUT")
                UIApplication.resetApp()
            }
        }
@@ -39,9 +40,10 @@ extension MypageViewModel {
     
     func deleteWithdraw(authorizationCode: String) {
         NetworkService.shared.authService.deleteWithdraw(authorizationCode: authorizationCode) { result in
-            result.handleNetworkResult(result) { response in
+            result.handleNetworkResult(result, onSuccessVoid: {
+                print("🛠️ RESTART APPLICATION 🛠️ - WITHDRAW")
                 UIApplication.resetApp()
-            }
+            })
         }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Onboarding/View/OnboardingViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Onboarding/View/OnboardingViewController.swift
@@ -97,7 +97,7 @@ private extension OnboardingViewController {
     
     @objc func nextButtonDidTap() {
         if isFinal() {
-            // 온보딩의 마지막일 경우, 로그인 페이지로 이동
+            // 온보딩의 마지막일 경우, 대학선택으로 이동
             presentUnivSelectView()
         } else {
             // 온보딩의 마지막 페이지가 아니면, 다음 로티로 이동
@@ -115,6 +115,7 @@ private extension OnboardingViewController {
             if let window = windowScene.windows.first {
                 let navigationController = HankkiNavigationController(rootViewController: TabBarController())
                 window.rootViewController = navigationController
+                navigationController.pushViewController(UnivSelectViewController(), animated: false)
             }
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Present/Onboarding/View/OnboardingViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Onboarding/View/OnboardingViewController.swift
@@ -39,7 +39,6 @@ final class OnboardingViewController: BaseViewController {
     
     override func setupStyle() {
         animationView.do {
-            
             $0.contentMode = .scaleAspectFill
             $0.loopMode = .loop
         }

--- a/Hankkijogbo/Hankkijogbo/Present/Onboarding/View/OnboardingViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Onboarding/View/OnboardingViewController.swift
@@ -98,7 +98,7 @@ private extension OnboardingViewController {
     @objc func nextButtonDidTap() {
         if isFinal() {
             // 온보딩의 마지막일 경우, 로그인 페이지로 이동
-            presentLoginView()
+            presentUnivSelectView()
         } else {
             // 온보딩의 마지막 페이지가 아니면, 다음 로티로 이동
             currentAnimationIndex += 1
@@ -107,11 +107,16 @@ private extension OnboardingViewController {
     }
     
     @objc func skipButtonDidTap() {
-        presentLoginView()
+        presentUnivSelectView()
     }
     
-    func presentLoginView() {
-        self.view.window?.rootViewController = LoginViewController()
+    func presentUnivSelectView() {
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            if let window = windowScene.windows.first {
+                let navigationController = HankkiNavigationController(rootViewController: TabBarController())
+                window.rootViewController = navigationController
+            }
+        }
     }
     
     func isFinal() -> Bool {

--- a/Hankkijogbo/Hankkijogbo/Present/Splash/SplashViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Splash/SplashViewController.swift
@@ -18,7 +18,7 @@ final class SplashViewController: BaseViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         if isLogin() {
             getUniversity()
         } else {
@@ -87,58 +87,19 @@ private extension SplashViewController {
     }
 }
 
-extension SplashViewController {
+private extension SplashViewController {
     func getUniversity() {
-        // 사용자의 대학을 조회한다.
+        UserDefaults.standard.removeUniversity()
+        
         NetworkService.shared.userService.getMeUniversity { result in
-            switch result {
-            case .success(let response):
-                // 사용자 대학 있음
-                // 로컬에 대학 정보 저장
-                if let university = response?.data {
-                    let university: UniversityModel = UniversityModel(id: university.id,
-                                                                      name: university.name,
-                                                                      longitude: university.longitude,
-                                                                      latitude: university.latitude)
-                    UserDefaults.standard.saveUniversity(university)
-                }
+            result.handleNetworkResult(result) { response in
                 
-            case .notFound: 
-                // 사용자 대학 없음.
-                UserDefaults.standard.removeUniversity()
-            case .unAuthorized:
-                // Access Token 만료
-                // Access Token을 다시 발급 받기 위해 reissue API 를 호출한다.
-                if !UserDefaults.standard.getAccesshToken().isEmpty { self.postReissue() }
-            
-            default:
-                print("로그인 중 나약한 개발자의 힘으로는 해결할 수 없는 레전드 에러 발생", result)
-                return
-            }
-            
-            self.presentHomeView()
-        }
-    }
-    
-    func postReissue() {
-        NetworkService.shared.authService.postReissue { result in
-            switch result {
-            case .success(let response):
-                // Refresh Token 발급 완료
-                let accessToken = response?.data.accessToken ?? ""
-                let refreshToken = response?.data.refreshToken ?? ""
-                UserDefaults.standard.saveTokens(accessToken: accessToken, refreshToken: refreshToken)
-    
-            case .unAuthorized:
-                // Refresh Token 만료
-                // Refresh, Access Token을 다시 발급 받기 위해 로그인 창으로 돌아간다.
-                UserDefaults.standard.removeTokens()
-                self.presentOnboardingView()
-                return
-            
-            default:
-                print("리프레시 토큰을 겟하는 중 나약한 개발자의 힘으로는 해결할 수 없는 레전드 에러 발생", result)
-                return
+                let university: UniversityModel = UniversityModel(id: response.data.id,
+                                                                  name: response.data.name,
+                                                                  longitude: response.data.longitude,
+                                                                  latitude: response.data.latitude)
+                UserDefaults.standard.saveUniversity(university)
+                self.presentHomeView()
             }
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Present/Splash/SplashViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Splash/SplashViewController.swift
@@ -22,7 +22,7 @@ final class SplashViewController: BaseViewController {
         if isLogin() {
             getUniversity()
         } else {
-            presentOnboardingView()
+            presentLoginView()
         }
     }
     
@@ -73,16 +73,16 @@ private extension SplashViewController {
     }
     
     func presentHomeView() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             let navigationController = HankkiNavigationController(rootViewController: TabBarController())
             self.view.window?.rootViewController = navigationController
             navigationController.popToRootViewController(animated: false)
         }
     }
     
-    func presentOnboardingView() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-            self.view.window?.rootViewController = OnboardingViewController()
+    func presentLoginView() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.view.window?.rootViewController = LoginViewController()
         }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/ZipList/View/ZipListViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/ZipList/View/ZipListViewController.swift
@@ -37,9 +37,8 @@ final class ZipListViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
         setupNavigationBar()
-        viewModel.getZipList(completion: {_ in})
+        viewModel.getZipList()
     }
     
     override func setupStyle() {
@@ -132,19 +131,20 @@ private extension ZipListViewController {
     }
     
     func deleteZip() {
-//        print(collectionView.indexPathsForSelectedItems)
         let selectedItemItems: [Int] = collectionView.indexPathsForSelectedItems?
             .filter { $0.item != 0 }
             .map { indexPath in
                 viewModel.zipList[indexPath.item - 1].id
             } ?? []
         
-        print(selectedItemItems, "을 삭제합니다.")
-        
         let request: PostZipBatchDeleteRequestDTO = PostZipBatchDeleteRequestDTO(favoriteIds: selectedItemItems)
-        viewModel.postZipBatchDelete(requestBody: request, completion: {_ in})
-        setIsEditMode()
-        dismiss(animated: false)
+        viewModel.postZipBatchDelete(requestBody: request) {
+            self.setIsEditMode()
+            self.dismiss(animated: false) {
+                self.viewModel.zipList = []
+                self.viewModel.getZipList()
+            }
+        }
     }
     
     func setIsEditMode() {
@@ -221,7 +221,6 @@ extension ZipListViewController: UICollectionViewDelegate {
                 if indexPath.item == 0 {
                     navigateToCreateZipViewController()
                 } else {
-                    print(indexPath.item, "으로 이동합니다.")
                     // 첫 족보 추가하기 셀은 리스트에 포함하지 않으므로 1을 뺀다
                     navigateToHankkiListViewController(zipId: self.viewModel.zipList[indexPath.item - 1].id)
                 }

--- a/Hankkijogbo/Hankkijogbo/Present/ZipList/ViewModel/ZipListViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/ZipList/ViewModel/ZipListViewModel.swift
@@ -19,7 +19,7 @@ final class ZipListViewModel {
 }
 
 extension ZipListViewModel {
-    func getZipList(completion: @escaping (Bool) -> Void) {
+    func getZipList() {
         NetworkService.shared.userService.getMeZipList { result in
             result.handleNetworkResult(result) { response in
                 self.zipList = response.data.favorites.map {
@@ -29,9 +29,9 @@ extension ZipListViewModel {
         }
     }
     
-    func postZipBatchDelete(requestBody: PostZipBatchDeleteRequestDTO, completion: @escaping (Bool) -> Void) {
+    func postZipBatchDelete(requestBody: PostZipBatchDeleteRequestDTO, completion: @escaping () -> Void) {
         NetworkService.shared.zipService.postZipBatchDelete(requesBody: requestBody) { result in
-            result.handleNetworkResult(result)
+            result.handleNetworkResult(result, onSuccessVoid: completion)
         }
     }
 }


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- Login -> Onboarding -> Univ Select 으로 로직 변경했습니다. (나의 실수, 정말 미안)

- HankkiList View Model에 Network Result 리펙토링이 안되어서 적용했습니다.

- status code 204 대응
success 중 status code가 204로 오는 경우 response가 nil로 와서 decode 에러가 발생합니다. 해당 이슈 대응 로직을 작성했습니다. (후술)

- 401 에러(엑세스 토큰 만료)처리
401 에러 발생시 postReissue를 통해 엑세스 토큰을 재발급합니다. 
이때 리프레시 토큰도 만료되었으면 application의 유저 정보를 지우고, 다시 로그인을 진행합니다.


## 🚨 참고 사항
- status code 204 처리 방법
```swift
// NetworkResult.swift

extension NetworkResult {
    func handleNetworkResult(_ result: NetworkResult, onSuccess: ((T) -> Void)? = nil, onSuccessVoid: (() -> Void)? = nil) {
        switch result {
        case .success(let response):
            if let res = response {
                onSuccess?(res)
            } else if T.self == Void.self {
                onSuccessVoid?()
            } else {
                print("🚨 RESPONSE IS NIL 🚨")
            }
            
        case .unAuthorized:
            // 401 error
            // access token이 올바르지 않거나, 만료된 경우
            self.postReissue()
            
        default:
            // TODO: - 상세한 분기처리 필요 (기디 논의 필요)
            // 프로그램 로직 내부에 오류가 발생했을 경우, 모달창을 띄웁니다.
            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                let delegate = windowScene.delegate as? SceneDelegate,
                let rootViewController = delegate.window?.rootViewController {
                rootViewController.showAlert(titleText: "오류 발생",
                                             subText: result.stateDescription,
                                             primaryButtonText: "확인")
            }
        }
    }
}
```
204의 경우 서버에서 별도의 data를 보내지 않습니다. Void값이 오는데, emptyDTO를 쓰는 경우 타입이 같지 않아 디코딩 오류가 나게 됩니다.
NetworkResult<Void>로 선언 할 경우 response의 optional을 푸는 과정에서 예외처리 과정으로 빠지게 됩니다. 그래서, response 값이 nil이어도 호출할 수 있는 `onSuccessVoid` 클로저를 추가했습니다.

```swift
//MypageViewModel.swift
func deleteWithdraw(authorizationCode: String) {
        NetworkService.shared.authService.deleteWithdraw(authorizationCode: authorizationCode) { result in
            result.handleNetworkResult(result, onSuccessVoid: {
                print("🛠️ RESTART APPLICATION 🛠️ - WITHDRAW")
                UIApplication.resetApp()
            })
        }
    }
```
위와 같은 방식으로 결과가 204인경우 실행할 로직을 작성해주시면됩니다.


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #155
