### PR TITLE
[Network] #168 - 통신에러 클라이언트에서 표시

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Global/Components/HankkiToasts/BlackToastView.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/HankkiToasts/BlackToastView.swift
@@ -17,7 +17,7 @@ final class BlackToastView: BaseView {
     typealias ButtonAction = (() -> Void)
     
     var message: String
-    @objc var action: ButtonAction
+    @objc var action: ButtonAction?
     
     // MARK: - UI Properties
     
@@ -27,7 +27,7 @@ final class BlackToastView: BaseView {
     
     // MARK: - Life Cycle
     
-    init(message: String, action: @escaping ButtonAction) {
+    init(message: String, action: ButtonAction? = nil) {
         self.message = message
         self.action = action
         super.init(frame: .zero)
@@ -43,25 +43,38 @@ final class BlackToastView: BaseView {
     // MARK: - Func
     
     override func setupHierarchy() {
-        addSubviews(messageLabel, actionButton, tapDetectView)
+        if action == nil {
+            addSubview(messageLabel)
+        } else {
+            addSubviews(messageLabel, actionButton, tapDetectView)
+        }
     }
     
     override func setupLayout() {
         self.snp.makeConstraints {
-            $0.width.equalTo(343)
+            $0.width.equalTo(UIScreen.getDeviceWidth() - 16*2)
             $0.height.equalTo(49)
         }
+        
         messageLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().inset(22)
+            if action == nil {
+                $0.centerX.equalToSuperview()
+            } else {
+                $0.leading.equalToSuperview().inset(22)
+            }
         }
-        actionButton.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(22)
-        }
-        tapDetectView.snp.makeConstraints {
-            $0.centerY.trailing.width.equalTo(actionButton)
-            $0.height.equalToSuperview()
+        
+        if action != nil {
+            actionButton.snp.makeConstraints {
+                $0.centerY.equalToSuperview()
+                $0.trailing.equalToSuperview().inset(22)
+            }
+            
+            tapDetectView.snp.makeConstraints {
+                $0.centerY.trailing.width.equalTo(actionButton)
+                $0.height.equalToSuperview()
+            }
         }
     }
     
@@ -94,6 +107,6 @@ private extension BlackToastView {
     // MARK: - @objc
     
     @objc func actionButtonDidTap() {
-        action()
+        action?()
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
@@ -60,8 +60,13 @@ enum StringLiterals {
         }
         
         enum NetworkError {
-            static let title = "네트워크 오류가 발생했어요."
+            static let title = "네트워크 오류가 발생했어요"
             static let sub = "네트워크 연결 상태를 확인하고 다시 시도해주세요"
+        }
+        
+        enum AccessError {
+            static let title = "로그인 유효기간이 만료되었어요"
+            static let sub = "처음부터 다시 로그인해주세요"
         }
     }
     
@@ -70,6 +75,8 @@ enum StringLiterals {
         static let see = "보기"
         static let addToMyZipWhite = "나의 족보에 추가했어요"
         static let move = "이동"
+        
+        static let serverError = "오류가 발생했어요. 다시 시도해주세요."
     }
     
     enum Toolbar {

--- a/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
@@ -63,11 +63,6 @@ enum StringLiterals {
             static let title = "네트워크 오류가 발생했어요"
             static let sub = "네트워크 연결 상태를 확인하고 다시 시도해주세요"
         }
-        
-        enum AccessError {
-            static let title = "로그인 유효기간이 만료되었어요"
-            static let sub = "처음부터 다시 로그인해주세요"
-        }
     }
     
     enum Toast {
@@ -77,6 +72,7 @@ enum StringLiterals {
         static let move = "이동"
         
         static let serverError = "오류가 발생했어요. 다시 시도해주세요."
+        static let accessError = "로그인 유효기간이 만료되었어요. 재로그인 해주세요."
     }
     
     enum Toolbar {

--- a/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
@@ -58,6 +58,11 @@ enum StringLiterals {
             static let title = "조금만 기다려주세요"
             static let sub = "친구에게 내 족보를 공유할 수 있도록\n준비 중이에요"
         }
+        
+        enum NetworkError {
+            static let title = "네트워크 오류가 발생했어요."
+            static let sub = "네트워크 연결 상태를 확인하고 다시 시도해주세요"
+        }
     }
     
     enum Toast {

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
@@ -64,7 +64,7 @@ extension UIApplication {
         }
     }
     
-    static func showBlackToast(message: String, action: @escaping (() -> Void)) {
+    static func showBlackToast(message: String, action: (() -> Void)? = nil) {
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
             let delegate = windowScene.delegate as? SceneDelegate,
            let rootViewController = delegate.window?.rootViewController {

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
@@ -63,4 +63,12 @@ extension UIApplication {
             )
         }
     }
+    
+    static func showBlackToast(message: String, action: @escaping (() -> Void)) {
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+            let delegate = windowScene.delegate as? SceneDelegate,
+           let rootViewController = delegate.window?.rootViewController {
+            rootViewController.showBlackToast(message: message, action: action)
+        }
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UIViewController+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UIViewController+.swift
@@ -103,7 +103,7 @@ extension UIViewController {
     /// 하단에 뜨는 검정 토스트뷰를 띄우는 함수
     func showBlackToast(
         message: String,
-        action: @escaping (() -> Void)
+        action: (() -> Void)? = nil
     ) {
         let toastView = BlackToastView(message: message, action: action)
         view.addSubview(toastView)

--- a/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
@@ -76,13 +76,9 @@ final class MoyaPlugin: PluginType {
         print(log)
         
         // 네트워크 연결 오류 Alert창 표출
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let delegate = windowScene.delegate as? SceneDelegate,
-           let rootViewController = delegate.window?.rootViewController {
-            rootViewController.showAlert(
-                titleText: "네트워크 연결 오류",
-                subText: "네트워크 오류로 \n서비스 접속이 불가능해요",
-                primaryButtonText: "확인")
-        }
+        UIApplication.showAlert(titleText: StringLiterals.Alert.NetworkError.title,
+                                subText: StringLiterals.Alert.NetworkError.sub,
+                                primaryButtonText: StringLiterals.Alert.check,
+                                primaryButtonHandler: { fatalError("❌ NETWORK ERROR ❌\n\n") })
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
@@ -79,6 +79,6 @@ final class MoyaPlugin: PluginType {
         UIApplication.showAlert(titleText: StringLiterals.Alert.NetworkError.title,
                                 subText: StringLiterals.Alert.NetworkError.sub,
                                 primaryButtonText: StringLiterals.Alert.check,
-                                primaryButtonHandler: { fatalError("❌ NETWORK ERROR ❌\n\n") })
+                                primaryButtonHandler: { exit(0) })
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
@@ -60,20 +60,15 @@ extension NetworkResult {
             self.postReissue()
             
         default:
-            // TODO: - 상세한 분기처리 필요 (기디 논의 필요)
-            // 프로그램 로직 내부에 오류가 발생했을 경우, 모달창을 띄웁니다.
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                let delegate = windowScene.delegate as? SceneDelegate,
-                let rootViewController = delegate.window?.rootViewController {
-                rootViewController.showAlert(titleText: "오류 발생",
-                                             subText: self.stateDescription,
-                                             primaryButtonText: "확인")
-            }
+            UIApplication.showBlackToast(message: StringLiterals.Toast.serverError, action: {})
         }
     }
 }
 
 private extension NetworkResult {
+    // 401 error
+    // access token이 올바르지 않거나, 만료된 경우
+    // access token을 재발급 받는다
     func postReissue() {
         NetworkService.shared.authService.postReissue { result in
             switch result {
@@ -81,8 +76,17 @@ private extension NetworkResult {
                 UserDefaults.standard.saveTokens(accessToken: response?.data.accessToken ?? "",
                                                  refreshToken: response?.data.refreshToken ?? "")
             default:
+                // 401, 404 ...
+                // access token을 재발급 받는 중 error가 났을 경우
+                // refresh token이 정상적이지 않을 경우
+                // 로그인을 다시 진행해 refresh token을 재발급 받는다.
                 print("🛠️ RESET APPLICATION 🛠️\n\n")
-                UIApplication.resetApp()
+                UserDefaults.standard.removeUserInformation()
+
+                UIApplication.showAlert(titleText: StringLiterals.Alert.AccessError.title,
+                                        subText: StringLiterals.Alert.AccessError.sub,
+                                        primaryButtonText: StringLiterals.Alert.check,
+                                        primaryButtonHandler: { UIApplication.resetApp() })
             }
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
@@ -60,7 +60,7 @@ extension NetworkResult {
             self.postReissue()
             
         default:
-            UIApplication.showBlackToast(message: StringLiterals.Toast.serverError, action: {})
+            UIApplication.showBlackToast(message: StringLiterals.Toast.serverError)
         }
     }
 }
@@ -81,12 +81,8 @@ private extension NetworkResult {
                 // refresh token이 정상적이지 않을 경우
                 // 로그인을 다시 진행해 refresh token을 재발급 받는다.
                 print("🛠️ RESET APPLICATION 🛠️\n\n")
-                UserDefaults.standard.removeUserInformation()
-
-                UIApplication.showAlert(titleText: StringLiterals.Alert.AccessError.title,
-                                        subText: StringLiterals.Alert.AccessError.sub,
-                                        primaryButtonText: StringLiterals.Alert.check,
-                                        primaryButtonHandler: { UIApplication.resetApp() })
+                UIApplication.resetApp()
+                UIApplication.showBlackToast(message: StringLiterals.Toast.accessError)
             }
         }
     }


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- network error를 표시하는 모달창을 구현했습니다.
- 서버, 클라이언트 에러를 표시하는 토스트 메세지를 구현했습니다.


## 🚨 참고 사항
<img width="403" alt="Screenshot 2024-08-13 at 4 25 01 PM" src="https://github.com/user-attachments/assets/5dc83f7f-8d75-4889-92b9-27e1aa526923">

```swift
 init(message: String, action: ButtonAction? = nil) {
        self.message = message
        self.action = action
        super.init(frame: .zero)
        
        addGesture()
        removeViewWithAnimation()
    }
```
으로, action을 nil값으로 설정하면 중앙 정렬된 토스트 메세지가 표시됩니다.
action에 클로저를 할당해주시면, 보기 버튼이 표시되어 해당 action을 수행할 수 있습니다.



## 📸 스크린샷
|    구현 내용    |   Modal   |   Toast   | 
| :-------------: | :----------: | :----------: |
|  | <img src = "https://github.com/user-attachments/assets/15f47419-d7a8-4b9b-a622-adcba06ff1e6" width ="250"> | <img src = "https://github.com/user-attachments/assets/7199f15b-b3fb-4a00-8783-6949d6b66c69" width ="250"> | 


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #168 
