### PR TITLE
[Fix] #202 - Zip Bottom Sheet, Create Zip 관련 로직 수정

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Global/Components/HankkiToasts/BlackToastView.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/HankkiToasts/BlackToastView.swift
@@ -48,7 +48,6 @@ final class BlackToastView: BaseView {
         } else {
             addSubviews(messageLabel, actionButton, tapDetectView)
         }
-        print("✔️\(String(describing: self.superview)) \(message)")
     }
     
     override func setupLayout() {

--- a/Hankkijogbo/Hankkijogbo/Global/Components/HankkiToasts/BlackToastView.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/HankkiToasts/BlackToastView.swift
@@ -48,6 +48,7 @@ final class BlackToastView: BaseView {
         } else {
             addSubviews(messageLabel, actionButton, tapDetectView)
         }
+        print("✔️\(String(describing: self.superview)) \(message)")
     }
     
     override func setupLayout() {

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
@@ -64,11 +64,27 @@ extension UIApplication {
         }
     }
     
+    /// 하단에 뜨는 검정 토스트뷰를 띄우는 함수
     static func showBlackToast(message: String, action: (() -> Void)? = nil) {
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-            let delegate = windowScene.delegate as? SceneDelegate,
-           let rootViewController = delegate.window?.rootViewController {
-            rootViewController.showBlackToast(message: message, action: action)
+        
+        let toastView = BlackToastView(message: message, action: action)
+        
+        // 토스트 메시지를 최상위 윈도우에 추가
+        if let topWindow = shared.connectedScenes
+            .filter({ $0.activationState == .foregroundActive })
+            .compactMap({ $0 as? UIWindowScene })
+            .first?.windows
+            .filter({ $0.isKeyWindow }).first {
+            
+            topWindow.addSubview(toastView)
+            toastView.snp.makeConstraints {
+                $0.centerX.equalToSuperview()
+                if UIScreen.hasNotch {
+                    $0.bottom.equalTo(topWindow.safeAreaLayoutGuide).offset(-16)
+                } else {
+                    $0.bottom.equalToSuperview().inset(16)
+                }
+            }
         }
     }
     

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UIViewController+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UIViewController+.swift
@@ -146,7 +146,7 @@ extension UIViewController {
     func presentMyZipListBottomSheet(id: Int) {
         let viewController = MyZipListBottomSheetViewController(storeId: id)
         viewController.modalTransitionStyle = .crossDissolve
-        viewController.modalPresentationStyle = .overFullScreen
+        viewController.modalPresentationStyle = .overFullScreen        
         self.present(viewController, animated: false, completion: nil)
     }
     

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -57,15 +57,15 @@ final class CreateZipViewController: BaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-         super.viewWillAppear(animated)
-         setupNavigationBar()
+        super.viewWillAppear(animated)
+        setupNavigationBar()
     }
     
     // MARK: - Set UI
     
     override func setupStyle() {
         viewTitle.do {
-            $0.attributedText = UILabel.setupAttributedText(for: PretendardStyle.h1, 
+            $0.attributedText = UILabel.setupAttributedText(for: PretendardStyle.h1,
                                                             withText: StringLiterals.CreateZip.viewTitle,
                                                             color: .gray900)
         }
@@ -75,7 +75,7 @@ final class CreateZipViewController: BaseViewController {
                                                             withText: StringLiterals.CreateZip.TitleInput.label,
                                                             color: .gray900)
         }
-    
+        
         titleInputTextField.do {
             $0.tag = 0
             $0.makeRoundBorder(cornerRadius: 10, borderWidth: 1, borderColor: .gray300)
@@ -113,17 +113,21 @@ final class CreateZipViewController: BaseViewController {
             $0.changePlaceholderColor(forPlaceHolder: StringLiterals.CreateZip.TagInput.placeholder,
                                       forColor: .gray400)
         }
+        
+        submitButton.do {
+            $0.setupDisabledButton()
+        }
     }
     
     override func setupHierarchy() {
         view.addSubviews(
             viewTitle,
-            titleInputTitle, 
-            titleInputTextField, 
+            titleInputTitle,
+            titleInputTextField,
             tagInputTitle,
             tagInputTextField,
             submitButton
-          )
+        )
         titleCountView.addSubview(titleCountLabel)
     }
     
@@ -194,7 +198,7 @@ private extension CreateZipViewController {
         titleInputTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         tagInputTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
     }
-
+    
     @objc func textFieldDidChange() {
         isFormValid()
     }
@@ -207,19 +211,27 @@ private extension CreateZipViewController {
     func submitButtonDidTap() {
         let arr = (tagInputTextField.text ?? "").split(separator: " ").map { String($0) }
         let data = PostZipRequestDTO(title: titleInputTextField.text ?? " ", details: arr)
-
-        viewModel.postZip(data) {
-            DispatchQueue.main.async {
-                // 족보 만들기를 완료해서, 서버에서 생성이되면 이전 페이지로 이동한다
-                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                   let rootViewController = windowScene.windows.first?.rootViewController as? UINavigationController {
-                    rootViewController.popViewController(animated: true)
-                    if let id = self.storeId {
-                        rootViewController.presentMyZipListBottomSheet(id: id)
-                    }
+        
+        viewModel.postZip(data, onConflict: resetTitleTextField, completion: dismissSelf)
+    }
+    
+    func resetTitleTextField() {
+        self.titleInputTextField.text = ""
+        submitButton.setupDisabledButton()
+    }
+    
+    func dismissSelf() {
+        DispatchQueue.main.async {
+            // 족보 만들기를 완료해서, 서버에서 생성이되면 이전 페이지로 이동한다
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let rootViewController = windowScene.windows.first?.rootViewController as? UINavigationController {
+                rootViewController.popViewController(animated: true)
+                if let id = self.storeId {
+                    rootViewController.presentMyZipListBottomSheet(id: id)
                 }
             }
         }
+        
     }
     
     func isFormValid() {
@@ -262,7 +274,7 @@ extension CreateZipViewController: UITextFieldDelegate {
             titleInputTextField.text = String(currentText.prefix(titleMaxCount))
             return
         }
-    
+        
         if currentText.count <= 1 {
             textField.text = ""
             return
@@ -335,7 +347,7 @@ extension CreateZipViewController: UITextFieldDelegate {
                 return false
             }
         }
-
+        
         // 텍스트 필드의 상태 : #
         // 현재 입력 : 백스페이스 (지우기)
         // 첫번째 태그를 작성하지 않고, 백페이스를 입력해 작성되어있던 #도 지우려는 경우
@@ -357,7 +369,7 @@ extension CreateZipViewController: UITextFieldDelegate {
             // -> 스페이스가 입력되지 않게 막아야한다.
             if currentText.contains(" ") {
                 return false
-            } 
+            }
             // 텍스트 필드의 상태 : #태그1
             // 첫번째 태그를 입력을 마무리하고, 두번째 태그를 작성하려고하는 경우
             // -> 첫번째 태그를 완성하고, 두번째 태그 작성을 위해 #을 자동으로 입력한다.
@@ -382,7 +394,7 @@ extension CreateZipViewController: UITextFieldDelegate {
             textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition)
         }
     }
-
+    
     func textFieldDidChangeSelection(_ textField: UITextField) {
         if textField.tag == 1 { moveCursorToEnd(textField) }
     }

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -11,6 +11,9 @@ final class CreateZipViewController: BaseViewController {
     
     // MARK: - Properties
     
+    private let isBottomSheetOpen: Bool
+    private let storeId: Int?
+    
     private let viewModel: CreateZipViewModel = CreateZipViewModel()
     
     private let tagMaxCount: Int = 9
@@ -34,6 +37,16 @@ final class CreateZipViewController: BaseViewController {
                                                buttonHandler: submitButtonDidTap)
     
     // MARK: - Life Cycle
+    
+    init(isBottomSheetOpen: Bool, storeId: Int? = nil) {
+        self.isBottomSheetOpen = isBottomSheetOpen
+        self.storeId = storeId
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -195,7 +208,18 @@ private extension CreateZipViewController {
         let arr = (tagInputTextField.text ?? "").split(separator: " ").map { String($0) }
         let data = PostZipRequestDTO(title: titleInputTextField.text ?? " ", details: arr)
 
-        viewModel.postZip(data)
+        viewModel.postZip(data) {
+            DispatchQueue.main.async {
+                // 족보 만들기를 완료해서, 서버에서 생성이되면 이전 페이지로 이동한다
+                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let rootViewController = windowScene.windows.first?.rootViewController as? UINavigationController {
+                    rootViewController.popViewController(animated: true)
+                    if let id = self.storeId {
+                        rootViewController.presentMyZipListBottomSheet(id: id)
+                    }
+                }
+            }
+        }
     }
     
     func isFormValid() {

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/ViewModel/CreateZipViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/ViewModel/CreateZipViewModel.swift
@@ -19,13 +19,18 @@ extension CreateZipViewModel {
         }
     }
 
-    func postZip(_ data: PostZipRequestDTO, completion: @escaping (() -> Void)) {
+    func postZip(_ data: PostZipRequestDTO,
+                 onConflict: @escaping(() -> Void),
+                 completion: @escaping (() -> Void)) {
         NetworkService.shared.zipService.postZip(requestBody: data) { result in
             switch result {
             case .conflict:
                 UIApplication.showAlert(titleText: StringLiterals.Alert.CreateZipConflict.title,
                                         subText: StringLiterals.Alert.CreateZipConflict.sub,
-                                        primaryButtonText: StringLiterals.Alert.CreateZipConflict.primaryButton)
+                                        primaryButtonText: StringLiterals.Alert.CreateZipConflict.primaryButton,
+                                        primaryButtonHandler: onConflict
+                )
+                             
             default:
                 result.handleNetworkResult { _ in
                     completion()

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/ViewModel/CreateZipViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/ViewModel/CreateZipViewModel.swift
@@ -19,7 +19,7 @@ extension CreateZipViewModel {
         }
     }
 
-    func postZip(_ data: PostZipRequestDTO) {
+    func postZip(_ data: PostZipRequestDTO, completion: @escaping (() -> Void)) {
         NetworkService.shared.zipService.postZip(requestBody: data) { result in
             switch result {
             case .conflict:
@@ -28,11 +28,7 @@ extension CreateZipViewModel {
                                         primaryButtonText: StringLiterals.Alert.CreateZipConflict.primaryButton)
             default:
                 result.handleNetworkResult { _ in
-                    DispatchQueue.main.async {
-                        // 족보 만들기를 완료해서, 서버에서 생성이되면 이전 페이지로 이동한다
-                        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                            let rootViewController = windowScene.windows.first?.rootViewController as? UINavigationController { rootViewController.popViewController(animated: true) }
-                    }
+                    completion()
                 }
             }
         }

--- a/Hankkijogbo/Hankkijogbo/Present/MyZipList/ViewModel/MyZipViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/MyZipList/ViewModel/MyZipViewModel.swift
@@ -31,10 +31,11 @@ final class MyZipViewModel {
     }
     
     /// 족보에 식당 추가
-    func postHankkiToZipAPI(request: PostHankkiToZipRequestDTO) {
+    func postHankkiToZipAPI(request: PostHankkiToZipRequestDTO, completion: @escaping (() -> Void)) {
         NetworkService.shared.zipService.postHankkiToZip(requestBody: request) { result in
             result.handleNetworkResult { [weak self] _ in
-                self?.showAddToZipCompleteToast?()
+//                self?.showAddToZipCompleteToast?()
+                completion()
             }
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Present/ZipList/View/ZipListViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/ZipList/View/ZipListViewController.swift
@@ -174,7 +174,7 @@ private extension ZipListViewController {
     }
     
     func navigateToCreateZipViewController() {
-        let createZipViewController = CreateZipViewController()
+        let createZipViewController = CreateZipViewController(isBottomSheetOpen: false)
         navigationController?.pushViewController(createZipViewController, animated: true)
     }
 }


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- Create Zip - Zip Bottom Sheet 연동
Zip Bottom Sheet 에서 Create Zip 으로 이동 한뒤, Zip을 생성하고 dismiss 된 상황에서 Zip Bottom Sheet가 닫히지 않고 열린채로 유지 될 수 있도록 로직을 변경했습니다.


## 🚨 참고 사항
- Black Toast show 함수 변경
현재 Toast Message 를 Notification을 활용한`self.showBalckToast`로 present 하고 있었습니다.
어떤 이유인지 모르겠지만, Notification을 적어둔 모든 viewcontroller에서 호출되면서 toast view가 7개 정도 생성되어, 투명도 적용이 안되었습니다. 
현재 로직은 UIApplication에 extension을 이용해 최상단 window에 balck toast를 띄우는 방식으로 로직을 변경했습니다.

하지만... 이것은 추후 은수언니와 논의를 해봐야할 듯합니다... @EunsuSeo01 Notion에 todo로 적어둘게요!

`UIApplication+.swift`
```swift
    /// 하단에 뜨는 검정 토스트뷰를 띄우는 함수
    static func showBlackToast(message: String, action: (() -> Void)? = nil) {
        
        let toastView = BlackToastView(message: message, action: action)
        
        // 토스트 메시지를 최상위 윈도우에 추가
        if let topWindow = shared.connectedScenes
            .filter({ $0.activationState == .foregroundActive })
            .compactMap({ $0 as? UIWindowScene })
            .first?.windows
            .filter({ $0.isKeyWindow }).first {
            
            topWindow.addSubview(toastView)
            toastView.snp.makeConstraints {
                $0.centerX.equalToSuperview()
                if UIScreen.hasNotch {
                    $0.bottom.equalTo(topWindow.safeAreaLayoutGuide).offset(-16)
                } else {
                    $0.bottom.equalToSuperview().inset(16)
                }
            }
        }
    }
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #202
