### PR TITLE
[Fix] #213 - 1.5차 기능 QA

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
@@ -115,8 +115,12 @@ extension TabBarController: UITabBarControllerDelegate {
         guard let index = viewControllers?.firstIndex(of: viewController) else { return true }
         
         if index == TabBarItem.allCases.firstIndex(of: .report) {
-            let reportViewController = ReportViewController()
-            navigationController?.pushViewController(reportViewController, animated: true)
+            if UserDefaults.standard.getUniversity()?.id == nil {
+                self.showAlert(titleText: StringLiterals.Alert.selectUniversityFirst, primaryButtonText: StringLiterals.Alert.check)
+            } else {
+                let reportViewController = ReportViewController()
+                navigationController?.pushViewController(reportViewController, animated: true)
+            }
             return false
         }
         

--- a/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
@@ -21,6 +21,7 @@ enum StringLiterals {
     }
     
     enum Home {
+        static let allUniversity = "전체"
         static let storeCategoryFilteringButton = "종류"
         static let priceFilteringButton = "가격대"
         static let sortFilteringButton = "정렬"
@@ -38,6 +39,7 @@ enum StringLiterals {
         static let thanksForReport = "님,\n변동사항을 알려주셔서 감사합니다 :)\n오늘도 저렴하고 든든한 식사하세요!"
         static let reallyReport = "정말 제보하시겠어요?"
         static let disappearInfoByReport = "제보시 식당 정보가 앱에서 사라져요"
+        static let selectUniversityFirst = "대학교를 먼저 선택해주세요"
         static let check = "확인"
         static let back = "돌아가기"
         static let stay = "유지하기"

--- a/Hankkijogbo/Hankkijogbo/Network/User/DTO/Request/PostMeUniversityRequestDTO.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/User/DTO/Request/PostMeUniversityRequestDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct PostMeUniversityRequestDTO: Codable {
-    let universityId: Int
+    let universityId: Int?
     let name: String
     let longitude: Double
     let latitude: Double

--- a/Hankkijogbo/Hankkijogbo/Network/User/DTO/Response/GetMeUniversityResponseDTO.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/User/DTO/Response/GetMeUniversityResponseDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct GetMeUniversityResponseData: Codable {
-    let id: Int
+    let id: Int?
     let name: String
     let longitude: Double
     let latitude: Double

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/Extension/CoreLocation.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/Extension/CoreLocation.swift
@@ -34,25 +34,24 @@ extension HomeViewController: CLLocationManagerDelegate {
             locationManager?.distanceFilter = kCLDistanceFilterNone
         }
         
-        // 위치 서비스 사용 가능 여부 확인
-        if CLLocationManager.locationServicesEnabled() {
-            locationManager?.requestWhenInUseAuthorization()
-        } else {
-            print("❌🌍❌ 위치 서비스가 비활성화 되었습니다. ❌🌍❌")
-        }
+        self.locationManager?.requestWhenInUseAuthorization()
     }
     
     // CLLocationManagerDelegate 메소드
-    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = CLLocationManager.authorizationStatus()
         switch status {
-        case .notDetermined:
-            print("❌🌍❌ 위치 접근 권한이 허용 되지 않았습니다. ❌🌍❌")
-        case .restricted, .denied:
-            print("❌🌍❌ 위치 접근 권한이 제한되거나 거부되었습니다. ❌🌍❌")
-            showLocationAccessDeniedAlert()
         case .authorizedWhenInUse, .authorizedAlways:
+            if let manager = locationManager {
+                manager.startUpdatingLocation()
+            }
             print("⭕️🌍⭕️ 위치 접근 권한이 허용되었습니다. ⭕️🌍⭕️")
-            locationManager?.startUpdatingLocation()
+        case .restricted, .denied:
+            showLocationAccessDeniedAlert()
+            print("❌🌍❌ 위치 접근 권한이 제한되거나 거부되었습니다. ❌🌍❌")
+        case .notDetermined:
+            requestLocationAuthorization()
+            print("❌🌍❌ 위치 접근 권한이 결정되지 않았습니다. ❌🌍❌")
         @unknown default:
             break
         }
@@ -95,7 +94,6 @@ extension HomeViewController: CLLocationManagerDelegate {
         case .authorizedWhenInUse, .authorizedAlways:
             // 위치 접근 권한이 허용된 경우 현재 위치로 이동
             if let manager = locationManager {
-                print("0824 현재 위치 \(locationManager)")
                 manager.startUpdatingLocation()
             }
         case .restricted, .denied:

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/Extension/CoreLocation.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/Extension/CoreLocation.swift
@@ -95,6 +95,7 @@ extension HomeViewController: CLLocationManagerDelegate {
         case .authorizedWhenInUse, .authorizedAlways:
             // 위치 접근 권한이 허용된 경우 현재 위치로 이동
             if let manager = locationManager {
+                print("0824 현재 위치 \(locationManager)")
                 manager.startUpdatingLocation()
             }
         case .restricted, .denied:
@@ -165,13 +166,21 @@ extension HomeViewController {
     func setupPosition() {
         var markers: [GetHankkiPinData] = viewModel.hankkiPins
         guard let university = UserDefaults.standard.getUniversity() else { return }
+        var initialPosition: NMGLatLng?
         
-        let initialPosition = NMGLatLng(lat: university.latitude, lng: university.longitude)
+        if university.latitude == 0.0 &&  university.longitude == 0.0 {
+            startLocationUpdates()
+        } else {
+            initialPosition = NMGLatLng(lat: university.latitude, lng: university.longitude)
+        }
+        
         viewModel.getHankkiPinAPI(universityId: university.id, storeCategory: "", priceCategory: "", sortOption: "", completion: { [weak self] pins in
             
             markers = self?.viewModel.hankkiPins ?? []
             self?.rootView.mapView.positionMode = .direction
-            self?.rootView.mapView.moveCamera(NMFCameraUpdate(scrollTo: initialPosition))
+            if let initialPosition = initialPosition {
+                self?.rootView.mapView.moveCamera(NMFCameraUpdate(scrollTo: initialPosition))
+            }
             
             self?.clearMarkers()
             

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
@@ -110,7 +110,7 @@ extension HomeViewController {
     }
     
     private func setupNavigationBar(mainTitle: String? = nil) {
-        let title = mainTitle ?? UserDefaults.standard.getUniversity()?.name ?? "전체"
+        let title = mainTitle ?? UserDefaults.standard.getUniversity()?.name ?? StringLiterals.Home.allUniversity
         print("Setting up navigation bar with title: \(title)")
         
         let type: HankkiNavigationType = HankkiNavigationType(hasBackButton: false,
@@ -271,10 +271,9 @@ extension HomeViewController: UnivSelectViewControllerDelegate {
         manager.startUpdatingLocation()
         
         shouldUpdateNavigationBar = false
-        setupNavigationBar(mainTitle: "전체")
+        setupNavigationBar(mainTitle: StringLiterals.Home.allUniversity)
         fetchAllRestaurantsAndPins()
     }
-    
     
     func fetchAllRestaurantsAndPins() {
         viewModel.getHankkiListAPI(storeCategory: "", priceCategory: "", sortOption: "") { _ in }

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
@@ -23,7 +23,7 @@ final class HomeViewController: BaseViewController {
     var markers: [NMFMarker] = []
     var presentMyZipBottomSheetNotificationName: String = "presentMyZipBottomSheetNotificationName"
     
-    private var universityId: Int? = UserDefaults.standard.getUniversity()?.id
+    private var universityId: Int?
     
     var shouldUpdateNavigationBar: Bool = true
     
@@ -60,7 +60,7 @@ final class HomeViewController: BaseViewController {
         requestLocationAuthorization()
         NotificationCenter.default.addObserver(self, selector: #selector(getNotificationForMyZipList), name: NSNotification.Name(presentMyZipBottomSheetNotificationName), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(setupBlackToast), name: NSNotification.Name(StringLiterals.NotificationName.setupToast), object: nil)
-        updateUniversityData(universityId: universityId)
+        updateUniversityData()
     }
     
     // MARK: - Set UI
@@ -164,6 +164,7 @@ extension HomeViewController {
 
 private extension HomeViewController {
     func loadInitialData() {
+        universityId = UserDefaults.standard.getUniversity()?.id
         viewModel.getHankkiListAPI(universityId: universityId, storeCategory: "", priceCategory: "", sortOption: "") { [weak self] success in
             let isEmpty = self?.viewModel.hankkiLists.isEmpty ?? true
             self?.viewModel.onHankkiListFetchCompletion?(success, isEmpty)
@@ -171,7 +172,9 @@ private extension HomeViewController {
         viewModel.getHankkiPinAPI(universityId: universityId, storeCategory: "", priceCategory: "", sortOption: "", completion: { _ in })
     }
     
-    func updateUniversityData(universityId: Int?) {
+    func updateUniversityData() {
+        let universityId = UserDefaults.standard.getUniversity()?.id
+        
         viewModel.getHankkiListAPI(universityId: universityId, storeCategory: "", priceCategory: "", sortOption: "") { [weak self] success in
             let isEmpty = self?.viewModel.hankkiLists.isEmpty ?? true
             self?.viewModel.onHankkiListFetchCompletion?(success, isEmpty)

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
@@ -164,7 +164,6 @@ extension HomeViewController {
 
 private extension HomeViewController {
     func loadInitialData() {
-        guard let universityId = UserDefaults.standard.getUniversity()?.id else { return }
         viewModel.getHankkiListAPI(universityId: universityId, storeCategory: "", priceCategory: "", sortOption: "") { [weak self] success in
             let isEmpty = self?.viewModel.hankkiLists.isEmpty ?? true
             self?.viewModel.onHankkiListFetchCompletion?(success, isEmpty)
@@ -173,8 +172,6 @@ private extension HomeViewController {
     }
     
     func updateUniversityData(universityId: Int?) {
-        guard let universityId = UserDefaults.standard.getUniversity()?.id else { return }
-        
         viewModel.getHankkiListAPI(universityId: universityId, storeCategory: "", priceCategory: "", sortOption: "") { [weak self] success in
             let isEmpty = self?.viewModel.hankkiLists.isEmpty ?? true
             self?.viewModel.onHankkiListFetchCompletion?(success, isEmpty)

--- a/Hankkijogbo/Hankkijogbo/Present/Report/Search/View/SearchViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Report/Search/View/SearchViewController.swift
@@ -293,9 +293,9 @@ private extension SearchViewController {
     }
     
     @objc func bottomButtonPrimaryHandler() {
-        guard let university = UserDefaults.standard.getUniversity() else { return }
+        guard let university = UserDefaults.standard.getUniversity(), let id = university.id else { return }
         guard let hankkiLocation = viewModel.selectedLocationData else { return }
-        let request = PostHankkiValidateRequestDTO(universityId: university.id, 
+        let request = PostHankkiValidateRequestDTO(universityId: id,
                                                    latitude: hankkiLocation.latitude,
                                                    longitude: hankkiLocation.longitude,
                                                    storeName: hankkiLocation.name)

--- a/Hankkijogbo/Hankkijogbo/Present/UnivSelect/Model/UniversityModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/UnivSelect/Model/UniversityModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct UniversityModel: Codable {
-    let id: Int
+    let id: Int?
     let name: String
     let longitude: Double
     let latitude: Double

--- a/Hankkijogbo/Hankkijogbo/Present/UnivSelect/View/UnivSelectViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/UnivSelect/View/UnivSelectViewController.swift
@@ -183,7 +183,6 @@ private extension UnivSelectViewController {
         case .authorizedWhenInUse, .authorizedAlways:
             viewModel.postMeUniversity(isNull: true)
             delegate?.didRequestLocationFocus()
-            navigationController?.popViewController(animated: true)
         case .restricted, .denied:
             // 위치 정보 접근이 거부된 경우, 서울시립대학교로 포커싱
             viewModel.currentUnivIndex = 24
@@ -196,6 +195,8 @@ private extension UnivSelectViewController {
         @unknown default:
             break
         }
+        
+        navigationController?.popViewController(animated: true)
     }
     
     func setupRegister() {

--- a/Hankkijogbo/Hankkijogbo/Present/UnivSelect/View/UnivSelectViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/UnivSelect/View/UnivSelectViewController.swift
@@ -181,6 +181,7 @@ private extension UnivSelectViewController {
         
         switch status {
         case .authorizedWhenInUse, .authorizedAlways:
+            viewModel.postMeUniversity(isNull: true)
             delegate?.didRequestLocationFocus()
             navigationController?.popViewController(animated: true)
         case .restricted, .denied:

--- a/Hankkijogbo/Hankkijogbo/Present/UnivSelect/ViewModel/UnivSelectViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/UnivSelect/ViewModel/UnivSelectViewModel.swift
@@ -36,8 +36,13 @@ extension UnivSelectViewModel {
         }
     }
 
-    func postMeUniversity() {
-        let currentUniversity: UniversityModel = universityList[currentUnivIndex]
+    func postMeUniversity(isNull: Bool = false) {
+        var currentUniversity: UniversityModel
+        if isNull {
+            currentUniversity = UniversityModel(id: nil, name: StringLiterals.Home.allUniversity, longitude: 0.0, latitude: 0.0)
+        } else {
+            currentUniversity = universityList[currentUnivIndex]
+        }
         let request: PostMeUniversityRequestDTO = PostMeUniversityRequestDTO(universityId: currentUniversity.id,
                                                                              name: currentUniversity.name,
                                                                              longitude: currentUniversity.longitude,


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- '전체'로 설정한 이후 홈화면 재진입 시 지도 및 이름이 이전에 선택한 대학교가 뜨는 이슈를 해결했습니다.
- 제보하기 또는 마이페이지 등 다른 탭바 화면으로 갔다가 홈으로 돌아왔을 때 홈 화면 네비바가 이상해지는 이슈를 해결했습니다.
- '전체'일 때 제보하기 탭바 클릭 시 대학교를 먼저 선택해달라는 Alert가 뜨도록 했습니다.
- 홈 VC의 `locationServicesEnabled` 호출부에서 보라색 경고 표시(`This method can cause UI unresponsiveness if invoked on the main thread. Instead, consider waiting for the locationManagerDidChangeAuthorization: callback and checking authorizationStatus first.`)가 떴었는데, 이를 해결했습니다.
- '전체'일 때 앱 처음 실행 시 리스트가 바로 안 불러와지는 이슈를 해결했습니다.

## 🚨 참고 사항
- 대부분의 이슈가 대학교를 선택하지 않고 '전체'로 설정 시 발생하는 에러들이었는데, 이는 해당 정보(= 설정된 대학교 없음)를 서버에 반영을 안 했기 때문이었습니다. 서버의 안내에 따라 **'찾는 대학교가 없어요. 둘러볼게요.'** 버튼 클릭 시, 사용자 대학교 설정 정보 생성 API로 `universityId`를 `nil`로 보내도록 수정하였더니 해결되었습니다.

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
> CoreLocation.swift
- 치명적인 보라색 에러가 뜨던 `locationServicesEnabled` 함수의 호출부를 제거하고, `locationManagerDidChangeAuthorization` 메소드를 사용하여 이를 해결했습니다. 테스트 완료.
- 원래 있던 `func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus)` 함수와 똑같은 역할을 하는 함수라서 지우고 하나로 통일했습니다.
```swift
// CLLocationManagerDelegate 메소드
func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
        let status = CLLocationManager.authorizationStatus()
        switch status {
        case .authorizedWhenInUse, .authorizedAlways:
            if let manager = locationManager {
                manager.startUpdatingLocation()
            }
            print("⭕️🌍⭕️ 위치 접근 권한이 허용되었습니다. ⭕️🌍⭕️")
        case .restricted, .denied:
            showLocationAccessDeniedAlert()
            print("❌🌍❌ 위치 접근 권한이 제한되거나 거부되었습니다. ❌🌍❌")
        case .notDetermined:
            requestLocationAuthorization()
            print("❌🌍❌ 위치 접근 권한이 결정되지 않았습니다. ❌🌍❌")
        @unknown default:
            break
        }
}
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #213 
