### PR TITLE
[Feature] #222 - Loaing View Custom

### DIFF
--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		865C3D022C44E9E0009D9BEA /* MoreButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C3D012C44E9E0009D9BEA /* MoreButton.swift */; };
 		865C3D042C4506C8009D9BEA /* ZipFooterTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C3D032C4506C8009D9BEA /* ZipFooterTableView.swift */; };
 		865D59C62C7B72C9004CC517 /* FullLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865D59C52C7B72C9004CC517 /* FullLoadingView.swift */; };
+		865D59C82C7B9105004CC517 /* LoadingViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865D59C72C7B9105004CC517 /* LoadingViewType.swift */; };
 		86685C522C3BC67D00C080C4 /* UnivSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */; };
 		86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */; };
 		86685C582C3BD89500C080C4 /* UnivCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */; };
@@ -288,6 +289,7 @@
 		865C3D062C45B4B3009D9BEA /* Target Support Files/Pods-Hankkijogbo/Pods-Hankkijogbo.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Target Support Files/Pods-Hankkijogbo/Pods-Hankkijogbo.release.xcconfig"; sourceTree = "<group>"; };
 		865C3D092C45B4D3009D9BEA /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		865D59C52C7B72C9004CC517 /* FullLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullLoadingView.swift; sourceTree = "<group>"; };
+		865D59C72C7B9105004CC517 /* LoadingViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewType.swift; sourceTree = "<group>"; };
 		86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewModel.swift; sourceTree = "<group>"; };
 		86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewController.swift; sourceTree = "<group>"; };
 		86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -881,6 +883,7 @@
 			isa = PBXGroup;
 			children = (
 				865D59C52C7B72C9004CC517 /* FullLoadingView.swift */,
+				865D59C72C7B9105004CC517 /* LoadingViewType.swift */,
 			);
 			path = LoadingView;
 			sourceTree = "<group>";
@@ -1797,6 +1800,7 @@
 				83DA28982C3852C5004819FA /* HankkiNavigationController.swift in Sources */,
 				86880BFF2C46ECD300CAEF58 /* PostMeUniversityRequestDTO.swift in Sources */,
 				86880BDA2C46CC8500CAEF58 /* ZipTargetType.swift in Sources */,
+				865D59C82C7B9105004CC517 /* LoadingViewType.swift in Sources */,
 				86880C382C4920A700CAEF58 /* PostZipRequestDTO.swift in Sources */,
 				865C3D042C4506C8009D9BEA /* ZipFooterTableView.swift in Sources */,
 				86B7611F2C3DE05800413059 /* HankkiListTableViewCell.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		865826062C4170BE00265401 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865826052C4170BE00265401 /* LoginViewController.swift */; };
 		865C3D022C44E9E0009D9BEA /* MoreButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C3D012C44E9E0009D9BEA /* MoreButton.swift */; };
 		865C3D042C4506C8009D9BEA /* ZipFooterTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C3D032C4506C8009D9BEA /* ZipFooterTableView.swift */; };
+		865D59C62C7B72C9004CC517 /* FullLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865D59C52C7B72C9004CC517 /* FullLoadingView.swift */; };
 		86685C522C3BC67D00C080C4 /* UnivSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */; };
 		86685C542C3BC68900C080C4 /* UnivSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */; };
 		86685C582C3BD89500C080C4 /* UnivCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */; };
@@ -286,6 +287,7 @@
 		865C3D052C45B4B3009D9BEA /* Target Support Files/Pods-Hankkijogbo/Pods-Hankkijogbo.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Target Support Files/Pods-Hankkijogbo/Pods-Hankkijogbo.debug.xcconfig"; sourceTree = "<group>"; };
 		865C3D062C45B4B3009D9BEA /* Target Support Files/Pods-Hankkijogbo/Pods-Hankkijogbo.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Target Support Files/Pods-Hankkijogbo/Pods-Hankkijogbo.release.xcconfig"; sourceTree = "<group>"; };
 		865C3D092C45B4D3009D9BEA /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		865D59C52C7B72C9004CC517 /* FullLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullLoadingView.swift; sourceTree = "<group>"; };
 		86685C512C3BC67D00C080C4 /* UnivSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewModel.swift; sourceTree = "<group>"; };
 		86685C532C3BC68900C080C4 /* UnivSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivSelectViewController.swift; sourceTree = "<group>"; };
 		86685C572C3BD89500C080C4 /* UnivCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnivCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -740,6 +742,7 @@
 				A240EA472C45273D000FF458 /* HankkiPaddingLabel */,
 				A29A441C2C6ADC11002B8D36 /* HankkiLineView */,
 				86E78D1C2C46B67400BE0DC3 /* EmptyView */,
+				865D59C42C7B71FE004CC517 /* LoadingView */,
 				A240EA0A2C3EFD54000FF458 /* HankkiCompositionalLayout */,
 				A240EA092C3EF712000FF458 /* HankkiReusableView */,
 				832546EA2C3F28D100B8C3DC /* HankkiDropDown */,
@@ -872,6 +875,14 @@
 				865826052C4170BE00265401 /* LoginViewController.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		865D59C42C7B71FE004CC517 /* LoadingView */ = {
+			isa = PBXGroup;
+			children = (
+				865D59C52C7B72C9004CC517 /* FullLoadingView.swift */,
+			);
+			path = LoadingView;
 			sourceTree = "<group>";
 		};
 		86685C4D2C3BC63500C080C4 /* UnivSelect */ = {
@@ -1776,6 +1787,7 @@
 				86880BF42C46E89C00CAEF58 /* GetMeUniversityResponseDTO.swift in Sources */,
 				A2FF94112C31660E001ADA03 /* BaseDTO.swift in Sources */,
 				837F10DC2C4A851A00E3CCE6 /* ReportCompleteViewController.swift in Sources */,
+				865D59C62C7B72C9004CC517 /* FullLoadingView.swift in Sources */,
 				86B761232C3EC87A00413059 /* ZipListCollectionViewCellModel.swift in Sources */,
 				83DBEDCA2C256AE70042BA48 /* UIViewController+.swift in Sources */,
 				A23D11972C47FFB90023480C /* SearchViewModel.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo/Global/Components/HankkiButtons/MainButton.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/HankkiButtons/MainButton.swift
@@ -33,12 +33,26 @@ final class MainButton: UIButton {
     
     typealias ButtonAction = () -> Void
     
-    let style: Style
-    let titleText: String
+    private let style: Style
+    private let titleText: String
     
-    // disable이 가능한 버튼인지 결정합니다.
-    // disable이 가능하면, 초기 설졍을 diable로 진행합니다.
-    let isDisable: Bool
+    private var isValid: Bool {
+        didSet {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.updateStyle()
+            }
+        }
+    }
+    
+    private var isSubmitted: Bool = false {
+        didSet {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                print("제출중...")
+            }
+        }
+    }
     
     var buttonHandler: ButtonAction?
     
@@ -48,22 +62,22 @@ final class MainButton: UIButton {
         type: MainButtonType = .primary,
         frame: CGRect = .zero,
         titleText: String,
-        isDisable: Bool = false,
+        isValid: Bool = true,
         buttonHandler: ButtonAction? = nil
     ) {
         self.style = type.style
         self.titleText = titleText
         
-        self.isDisable = isDisable
-        
         self.buttonHandler = buttonHandler
+        self.isValid = isValid
         
         super.init(frame: frame)
+    
         
         setupStyle()
         setupButtonAction()
     }
-   
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -82,22 +96,44 @@ extension MainButton {
 }
 
 extension MainButton {
-    func setupEnabledButton() {
-        self.do {
-            $0.backgroundColor = style.ableBackgroundColor
-            $0.isEnabled = true
-        }
+    func setupIsValid(_ isValid: Bool) {
+        self.isValid = isValid
     }
     
-    func setupDisabledButton() {
-        self.do {
-            $0.backgroundColor = style.disableBackgroundColor
-            $0.isEnabled = false
-        }
+    func setupIsSubmitted(_ isSubmitted: Bool) {
+        self.isSubmitted = isSubmitted
     }
+    //
+    //    func setupEnabledButton() {
+    //        self.do {
+    //            $0.backgroundColor = style.ableBackgroundColor
+    //            $0.isEnabled = true
+    //        }
+    //    }
+    //
+    //    func setupDisabledButton() {
+    //        self.do {
+    //            $0.backgroundColor = style.disableBackgroundColor
+    //            $0.isEnabled = false
+    //        }
+    //    }
 }
 
 private extension MainButton {
+    func updateStyle() {
+        self.do {
+            if isValid {
+                // 버튼이 유효한 경우 = enable
+                $0.backgroundColor = style.ableBackgroundColor
+                $0.isEnabled = true
+            } else {
+                // 버튼이 유효하지 않은 경우 = disable
+                $0.backgroundColor = style.disableBackgroundColor
+                $0.isEnabled = false
+            }
+        }
+    }
+    
     func setupStyle() {
         self.do {
             if let attributedTitle = UILabel.setupAttributedText(
@@ -107,16 +143,9 @@ private extension MainButton {
             ) {
                 $0.setAttributedTitle(attributedTitle, for: .normal)
             }
-            
-            if isDisable {
-                $0.backgroundColor = style.disableBackgroundColor
-                $0.isEnabled = false
-            } else {
-                $0.backgroundColor = style.ableBackgroundColor
-                $0.isEnabled = true
-            }
-            
             $0.makeRoundBorder(cornerRadius: 16, borderWidth: 0, borderColor: .clear)
         }
+        
+        updateStyle()
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Components/HankkiButtons/MainButton.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/HankkiButtons/MainButton.swift
@@ -73,7 +73,6 @@ final class MainButton: UIButton {
         
         super.init(frame: frame)
     
-        
         setupStyle()
         setupButtonAction()
     }
@@ -103,20 +102,6 @@ extension MainButton {
     func setupIsSubmitted(_ isSubmitted: Bool) {
         self.isSubmitted = isSubmitted
     }
-    //
-    //    func setupEnabledButton() {
-    //        self.do {
-    //            $0.backgroundColor = style.ableBackgroundColor
-    //            $0.isEnabled = true
-    //        }
-    //    }
-    //
-    //    func setupDisabledButton() {
-    //        self.do {
-    //            $0.backgroundColor = style.disableBackgroundColor
-    //            $0.isEnabled = false
-    //        }
-    //    }
 }
 
 private extension MainButton {

--- a/Hankkijogbo/Hankkijogbo/Global/Components/LoadingView/FullLoadingView.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/LoadingView/FullLoadingView.swift
@@ -1,0 +1,62 @@
+//
+//  FullLoadingView.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 8/25/24.
+//
+
+import UIKit
+
+import Lottie
+
+final class FullLoadingView: BaseView {
+    
+    // MARK: - UI Components
+    private let spinner: LottieAnimationView = LottieAnimationView()
+    
+    override func setupHierarchy() {
+        self.addSubview(spinner)
+    }
+    
+    override func setupLayout() {
+        spinner.snp.makeConstraints {
+            $0.size.equalTo(68)
+            $0.center.equalToSuperview()
+        }
+    }
+    
+    override func setupStyle() {
+        self.do {
+            $0.isHidden = true
+        }
+        
+        spinner.do {
+            $0.animation = LottieAnimation.named("loading")
+            $0.contentMode = .scaleAspectFill
+            $0.loopMode = .loop
+            $0.stop()
+        }
+    }
+}
+
+extension FullLoadingView {
+    func showLoadingView() {
+        self.do {
+            $0.isHidden = false
+        }
+        
+        spinner.do {
+            $0.play()
+        }
+    }
+    
+    func dismissLoadingView() {
+        self.do {
+            $0.isHidden = true
+        }
+        
+        spinner.do {
+            $0.stop()
+        }
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Global/Components/LoadingView/FullLoadingView.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/LoadingView/FullLoadingView.swift
@@ -40,17 +40,18 @@ final class FullLoadingView: BaseView {
 }
 
 extension FullLoadingView {
-    func showLoadingView() {
+    func showLoadingView(_ type: LoadingViewType) {
         self.do {
             $0.isHidden = false
         }
         
         spinner.do {
+            $0.isHidden = type == .submit
             $0.play()
         }
     }
     
-    func dismissLoadingView() {
+    func dismissLoadingView(_ type: LoadingViewType) {
         self.do {
             $0.isHidden = true
         }

--- a/Hankkijogbo/Hankkijogbo/Global/Components/LoadingView/LoadingViewType.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/LoadingView/LoadingViewType.swift
@@ -1,0 +1,12 @@
+//
+//  LoadingViewType.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 8/26/24.
+//
+
+enum LoadingViewType {
+    case fullView
+    case submit
+    case none
+}

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
@@ -88,7 +88,7 @@ extension UIApplication {
         }
     }
     
-    static func showLoadingView() {
+    static func showLoadingView(for type: LoadingViewType) {
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let delegate = windowScene.delegate as? SceneDelegate,
                           let rootViewController = delegate.window?.rootViewController as? UINavigationController,

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UIApplication+.swift
@@ -48,7 +48,7 @@ extension UIApplication {
         hightlightedColor: UIColor? = nil
     ) {
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-            let delegate = windowScene.delegate as? SceneDelegate,
+           let delegate = windowScene.delegate as? SceneDelegate,
            let rootViewController = delegate.window?.rootViewController {
             rootViewController.showAlert(
                 image: image,
@@ -85,24 +85,6 @@ extension UIApplication {
                     $0.bottom.equalToSuperview().inset(16)
                 }
             }
-        }
-    }
-    
-    static func showLoadingView(for type: LoadingViewType) {
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let delegate = windowScene.delegate as? SceneDelegate,
-                          let rootViewController = delegate.window?.rootViewController as? UINavigationController,
-                          let currentViewController = rootViewController.topViewController as? BaseViewController {
-                           currentViewController.showLoadingView()
-        }
-    }
-    
-    static func dismissLoadingView() {
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let delegate = windowScene.delegate as? SceneDelegate,
-                          let rootViewController = delegate.window?.rootViewController as? UINavigationController,
-                          let currentViewController = rootViewController.topViewController as? BaseViewController {
-                           currentViewController.dismissLoadingView()
         }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Auth/AuthAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Auth/AuthAPIService.swift
@@ -21,7 +21,7 @@ protocol AuthAPIServiceProtocol {
 
 final class AuthAPIService: BaseAPIService, AuthAPIServiceProtocol {
     
-    private let provider = MoyaProvider<AuthTargetType>(plugins: [MoyaPlugin()])
+    private let provider = MoyaProvider<AuthTargetType>(plugins: [MoyaPlugin.shared])
     
     func postLogin(accessToken: String, requestBody: PostLoginRequestDTO, completion: @escaping (NetworkResult<PostLoginResponseDTO>) -> Void) {
         provider.request(.postLogin(accessToken: accessToken, requestBody: requestBody)) { result in

--- a/Hankkijogbo/Hankkijogbo/Network/Auth/AuthTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Auth/AuthTargetType.swift
@@ -73,8 +73,7 @@ extension AuthTargetType: BaseTargetType {
     
     var loadingViewType: LoadingViewType {
         switch self {
-        case .deleteWithdraw: return .fullView
-        case .patchLogout: return .fullView
+        case .deleteWithdraw, .patchLogout: return .fullView
         default: return .none
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Network/Auth/AuthTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Auth/AuthTargetType.swift
@@ -70,4 +70,12 @@ extension AuthTargetType: BaseTargetType {
         case .patchLogout: return .patch
         }
     }
+    
+    var loadingViewType: LoadingViewType {
+        switch self {
+        case .deleteWithdraw: return .fullView
+        case .patchLogout: return .fullView
+        default: return .none
+        }
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
@@ -46,6 +46,7 @@ protocol BaseTargetType: TargetType {
     var pathParameter: String? { get }
     var queryParameter: [String: Any]? { get }
     var requestBodyParameter: Codable? { get }
+    var loadingViewType: LoadingViewType { get }
 }
 
 extension BaseTargetType {
@@ -103,4 +104,10 @@ extension BaseTargetType {
             return .requestPlain
         }
     }
+}
+
+enum LoadingViewType {
+    case fullView
+    case submit
+    case none
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
@@ -105,9 +105,3 @@ extension BaseTargetType {
         }
     }
 }
-
-enum LoadingViewType {
-    case fullView
-    case submit
-    case none
-}

--- a/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
@@ -12,7 +12,7 @@ import Moya
 
 final class MoyaPlugin: PluginType {
     
-    //MARK: - Properties
+    // MARK: - Properties
     
     weak var delegate: BaseViewControllerDelegate?
     
@@ -53,7 +53,6 @@ final class MoyaPlugin: PluginType {
     // MARK: - Response 받을 시 호출
     
     func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
-        
         setupLoading(false, target: target)
         
         switch result {

--- a/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
@@ -15,13 +15,26 @@ final class MoyaPlugin: PluginType {
     // MARK: - Request 보낼 시 호출
     
     func willSend(_ request: RequestType, target: TargetType) {
-
+        
         guard let httpRequest = request.request else {
             print("--> ❌🍚❌유효하지 않은 요청❌🍚❌")
             return
         }
-        DispatchQueue.main.async {
-            UIApplication.showLoadingView()
+        print("🛜 \(request)")
+        
+        let loadingViewType: LoadingViewType
+        if let targetWithLoading = target as? BaseTargetType {
+            loadingViewType = targetWithLoading.loadingViewType
+        } else {
+            loadingViewType = .none
+        }
+        
+        print("🥕 \(target) \(loadingViewType) 로딩뷰 시작")
+        
+        if loadingViewType == .fullView {
+            DispatchQueue.main.async {
+                UIApplication.showLoadingView(for: loadingViewType)
+            }
         }
         
         let url = httpRequest.description
@@ -39,14 +52,25 @@ final class MoyaPlugin: PluginType {
         log.append("=======================================================\n")
         print(log)
     }
-
+    
     // MARK: - Response 받을 시 호출
     
     func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
-        DispatchQueue.main.async {
-            UIApplication.dismissLoadingView()
+        
+        let loadingViewType: LoadingViewType
+        if let targetWithLoading = target as? BaseTargetType {
+            loadingViewType = targetWithLoading.loadingViewType
+        } else {
+            loadingViewType = .none
         }
         
+        print("🥕 \(target) \(loadingViewType) 로딩뷰 끝")
+        
+        if loadingViewType == .fullView {
+            DispatchQueue.main.async {
+                UIApplication.dismissLoadingView()
+            }
+        }
         switch result {
         case let .success(response):
             self.onSucceed(response)
@@ -54,7 +78,7 @@ final class MoyaPlugin: PluginType {
             self.onFail(error)
         }
     }
-
+    
     func onSucceed(_ response: Response) {
         let request = response.request
         let url = request?.url?.absoluteString ?? "nil"
@@ -62,14 +86,14 @@ final class MoyaPlugin: PluginType {
         
         var log = "🍚 [RESULT] =============================================\n"
         log.append("3️⃣ [\(statusCode)] \(url)\n")
-   
+        
         if let reString = String(bytes: response.data, encoding: String.Encoding.utf8) {
             log.append("\n4️⃣ \(reString)\n")
         }
         log.append("=======================================================\n")
         print(log)
     }
-
+    
     func onFail(_ error: MoyaError) {
         if let response = error.response {
             onSucceed(response)

--- a/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
@@ -12,6 +12,16 @@ import Moya
 
 final class MoyaPlugin: PluginType {
     
+    //MARK: - Properties
+    
+    weak var delegate: BaseViewControllerDelegate?
+    
+    // MARK: - Life Cycle
+    
+    static let shared = MoyaPlugin()
+    
+    private init() {}
+    
     // MARK: - Request 보낼 시 호출
     
     func willSend(_ request: RequestType, target: TargetType) {
@@ -20,22 +30,8 @@ final class MoyaPlugin: PluginType {
             print("--> ❌🍚❌유효하지 않은 요청❌🍚❌")
             return
         }
-        print("🛜 \(request)")
         
-        let loadingViewType: LoadingViewType
-        if let targetWithLoading = target as? BaseTargetType {
-            loadingViewType = targetWithLoading.loadingViewType
-        } else {
-            loadingViewType = .none
-        }
-        
-        print("🥕 \(target) \(loadingViewType) 로딩뷰 시작")
-        
-        if loadingViewType == .fullView {
-            DispatchQueue.main.async {
-                UIApplication.showLoadingView(for: loadingViewType)
-            }
-        }
+        setLoading(true, target: target)
         
         let url = httpRequest.description
         let method = httpRequest.httpMethod ?? "unknown method"
@@ -57,20 +53,8 @@ final class MoyaPlugin: PluginType {
     
     func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
         
-        let loadingViewType: LoadingViewType
-        if let targetWithLoading = target as? BaseTargetType {
-            loadingViewType = targetWithLoading.loadingViewType
-        } else {
-            loadingViewType = .none
-        }
+        setLoading(false, target: target)
         
-        print("🥕 \(target) \(loadingViewType) 로딩뷰 끝")
-        
-        if loadingViewType == .fullView {
-            DispatchQueue.main.async {
-                UIApplication.dismissLoadingView()
-            }
-        }
         switch result {
         case let .success(response):
             self.onSucceed(response)
@@ -119,5 +103,15 @@ private extension MoyaPlugin {
         if let url = URL(string: UIApplication.openSettingsURLString) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
+    }
+    
+    func setLoading(_ isLoading: Bool, target: TargetType) {
+        let loadingViewType: LoadingViewType
+        if let targetWithLoading = target as? BaseTargetType {
+            loadingViewType = targetWithLoading.loadingViewType
+        } else {
+            loadingViewType = .none
+        }
+        delegate?.setLoading(isLoading, type: loadingViewType)
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/MoyaPlugin.swift
@@ -25,13 +25,14 @@ final class MoyaPlugin: PluginType {
     // MARK: - Request 보낼 시 호출
     
     func willSend(_ request: RequestType, target: TargetType) {
+        setupLoading(true, target: target)
         
         guard let httpRequest = request.request else {
             print("--> ❌🍚❌유효하지 않은 요청❌🍚❌")
+            setupLoading(false, target: target)
             return
+            
         }
-        
-        setLoading(true, target: target)
         
         let url = httpRequest.description
         let method = httpRequest.httpMethod ?? "unknown method"
@@ -53,7 +54,7 @@ final class MoyaPlugin: PluginType {
     
     func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
         
-        setLoading(false, target: target)
+        setupLoading(false, target: target)
         
         switch result {
         case let .success(response):
@@ -105,13 +106,13 @@ private extension MoyaPlugin {
         }
     }
     
-    func setLoading(_ isLoading: Bool, target: TargetType) {
+    func setupLoading(_ isLoading: Bool, target: TargetType) {
         let loadingViewType: LoadingViewType
         if let targetWithLoading = target as? BaseTargetType {
             loadingViewType = targetWithLoading.loadingViewType
         } else {
             loadingViewType = .none
         }
-        delegate?.setLoading(isLoading, type: loadingViewType)
+        delegate?.setupLoading(isLoading, type: loadingViewType)
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkService.swift
@@ -21,3 +21,9 @@ final class NetworkService {
     let zipService: ZipAPIServiceProtocol = ZipAPIService()
     let reportService: ReportAPIServiceProtocol = ReportAPIService()
 }
+
+extension NetworkService {
+    func setDelegate(_ delegate: BaseViewControllerDelegate) {
+        MoyaPlugin.shared.delegate = delegate
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkService.swift
@@ -23,7 +23,7 @@ final class NetworkService {
 }
 
 extension NetworkService {
-    func setDelegate(_ delegate: BaseViewControllerDelegate) {
+    func setupDelegate(_ delegate: BaseViewControllerDelegate) {
         MoyaPlugin.shared.delegate = delegate
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Hankki/HakkiAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Hankki/HakkiAPIService.swift
@@ -39,7 +39,7 @@ extension HankkiAPIServiceProtocol {
 
 final class HankkiAPIService: BaseAPIService, HankkiAPIServiceProtocol {
     
-    private let provider = MoyaProvider<HankkiTargetType>(plugins: [MoyaPlugin()])
+    private let provider = MoyaProvider<HankkiTargetType>(plugins: [MoyaPlugin.shared])
     
     func postHankki(multipartData: [MultipartFormData], completion: @escaping (NetworkResult<PostHankkiResponseDTO>) -> Void) {
         provider.request(.postHankki(multipartData: multipartData)) { result in

--- a/Hankkijogbo/Hankkijogbo/Network/Hankki/HankkiTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Hankki/HankkiTargetType.swift
@@ -134,4 +134,19 @@ extension HankkiTargetType: BaseTargetType {
             return .delete
         }
     }
+    
+    var loadingViewType: LoadingViewType {
+        switch self {
+        case .getHankkiList: return .fullView
+        case .getHankkiDetail: return .fullView
+        case .getHankkiPin: return .fullView
+            
+        case .postHankkiValidate: return .submit
+        case .postHankki: return .submit
+        case .postHankkiFromOther: return .submit
+        case .deleteHankki: return .submit
+            
+        default: return .none
+        }
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Hankki/HankkiTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Hankki/HankkiTargetType.swift
@@ -137,15 +137,8 @@ extension HankkiTargetType: BaseTargetType {
     
     var loadingViewType: LoadingViewType {
         switch self {
-        case .getHankkiList: return .fullView
-        case .getHankkiDetail: return .fullView
-        case .getHankkiPin: return .fullView
-            
-        case .postHankkiValidate: return .submit
-        case .postHankki: return .submit
-        case .postHankkiFromOther: return .submit
-        case .deleteHankki: return .submit
-            
+        case .getHankkiList, .getHankkiDetail, .getHankkiPin: return .fullView  
+        case .postHankkiValidate, .postHankki, .postHankkiFromOther, .deleteHankki: return .submit
         default: return .none
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Network/Location/LocationAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Location/LocationAPIService.swift
@@ -16,7 +16,7 @@ protocol LocationAPIServiceProtocol {
 
 final class LocationAPIService: BaseAPIService, LocationAPIServiceProtocol {
     
-    private let provider = MoyaProvider<LocationTargetType>(plugins: [MoyaPlugin()])
+    private let provider = MoyaProvider<LocationTargetType>(plugins: [MoyaPlugin.shared])
     
     func getSearchedLocation(query: String, completion: @escaping (NetworkResult<GetSearchedLocationResponseDTO>) -> Void) {
         provider.request(.getSearchedLocation(query: query)) { result in

--- a/Hankkijogbo/Hankkijogbo/Network/Location/LocationTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Location/LocationTargetType.swift
@@ -14,6 +14,12 @@ enum LocationTargetType {
 }
 
 extension LocationTargetType: BaseTargetType {
+    var loadingViewType: LoadingViewType {
+        switch self {
+        case .getSearchedLocation: return .fullView
+        }
+    }
+    
     var headerType: HeaderType { return .accessTokenHeader }
     var utilPath: UtilPath { return .location }
     

--- a/Hankkijogbo/Hankkijogbo/Network/Report/ReportAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Report/ReportAPIService.swift
@@ -16,7 +16,7 @@ protocol ReportAPIServiceProtocol {
 
 final class ReportAPIService: BaseAPIService, ReportAPIServiceProtocol {
     
-    private let provider = MoyaProvider<ReportTargetType>(plugins: [MoyaPlugin()])
+    private let provider = MoyaProvider<ReportTargetType>(plugins: [MoyaPlugin.shared])
     
     func getReportedNumber(completion: @escaping (NetworkResult<GetReportedNumberResponseDTO>) -> Void) {
         provider.request(.getReportedNumber) { result in

--- a/Hankkijogbo/Hankkijogbo/Network/Report/ReportTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Report/ReportTargetType.swift
@@ -42,4 +42,10 @@ extension ReportTargetType: BaseTargetType {
         case .getReportedNumber: .get
         }
     }
+    
+    var loadingViewType: LoadingViewType {
+        switch self {
+        case .getReportedNumber: return .none
+        }
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/University/UniversityService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/University/UniversityService.swift
@@ -15,7 +15,7 @@ protocol UniversityAPIServiceProtocol {
 }
 
 final class UniversityAPIService: BaseAPIService, UniversityAPIServiceProtocol {
-    private let provider = MoyaProvider<UniversityTargetType>(plugins: [MoyaPlugin()])
+    private let provider = MoyaProvider<UniversityTargetType>(plugins: [MoyaPlugin.shared])
     
     func getUniversityList(completion: @escaping (NetworkResult<GetUniversityListResponseDTO>) -> Void) {
         provider.request(.getUniversityList) { result in

--- a/Hankkijogbo/Hankkijogbo/Network/University/UniversityTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/University/UniversityTargetType.swift
@@ -50,5 +50,11 @@ extension UniversityTargetType: BaseTargetType {
         switch self {
         case .getUniversityList: return .get
         }
-    }    
+    }
+    
+    var loadingViewType: LoadingViewType {
+        switch self {
+        case .getUniversityList: return .fullView
+        }
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/User/UserAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/User/UserAPIService.swift
@@ -24,7 +24,7 @@ protocol UserAPIServiceProtocol {
 
 final class UserAPIService: BaseAPIService, UserAPIServiceProtocol {
     
-    private let provider = MoyaProvider<UserTargetType>(plugins: [MoyaPlugin()])
+    private let provider = MoyaProvider<UserTargetType>(plugins: [MoyaPlugin.shared])
     
     func getMe(completion: @escaping (NetworkResult<GetMeResponseDTO>) -> Void) {
         provider.request(.getMe) { result in

--- a/Hankkijogbo/Hankkijogbo/Network/User/UserTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/User/UserTargetType.swift
@@ -72,9 +72,7 @@ extension UserTargetType: BaseTargetType {
     
     var loadingViewType: LoadingViewType {
         switch self {
-        case .getMeHankkiHeartList: return .fullView
-        case .getMeHankkiReportList: return .fullView
-        case .getMeZipList: return .fullView
+        case .getMeHankkiHeartList, .getMeHankkiReportList, .getMeZipList: return .fullView
         case .postMeUniversity: return .submit
         default: return .none
         }

--- a/Hankkijogbo/Hankkijogbo/Network/User/UserTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/User/UserTargetType.swift
@@ -69,5 +69,14 @@ extension UserTargetType: BaseTargetType {
              return .post
         }
     }
-
+    
+    var loadingViewType: LoadingViewType {
+        switch self {
+        case .getMeHankkiHeartList: return .fullView
+        case .getMeHankkiReportList: return .fullView
+        case .getMeZipList: return .fullView
+        case .postMeUniversity: return .submit
+        default: return .none
+        }
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Zip/ZipAPIService.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Zip/ZipAPIService.swift
@@ -23,7 +23,7 @@ protocol ZipAPIServiceProtocol {
 
 final class ZipAPIService: BaseAPIService, ZipAPIServiceProtocol {
     
-    private let provider = MoyaProvider<ZipTargetType>(plugins: [MoyaPlugin()])
+    private let provider = MoyaProvider<ZipTargetType>(plugins: [MoyaPlugin.shared])
     
     func deleteZipToHankki(requestBody: DeleteZipToHankkiRequestDTO, completion: @escaping (NetworkResult<Void>) -> Void) {
         provider.request(.deleteZipToHankki(requestBody: requestBody)) { result in

--- a/Hankkijogbo/Hankkijogbo/Network/Zip/ZipTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Zip/ZipTargetType.swift
@@ -85,14 +85,9 @@ extension ZipTargetType: BaseTargetType {
     
     var loadingViewType: LoadingViewType {
         switch self {
-        case .getZipList: return .fullView
-        case .getMyZipList: return .fullView
-        case .getZipDetail: return .fullView
-        case .postZip: return .submit
-        case .postZipBatchDelete: return .submit
-        case .deleteZipToHankki: return .submit
-        default:
-            return .none
+        case .getZipList, .getMyZipList, .getZipDetail: return .fullView
+        case .postZip, .postZipBatchDelete, .deleteZipToHankki: return .submit
+        default: return .none
         }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Zip/ZipTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Zip/ZipTargetType.swift
@@ -82,4 +82,17 @@ extension ZipTargetType: BaseTargetType {
             return .delete
         }
     }
+    
+    var loadingViewType: LoadingViewType {
+        switch self {
+        case .getZipList: return .fullView
+        case .getMyZipList: return .fullView
+        case .getZipDetail: return .fullView
+        case .postZip: return .submit
+        case .postZipBatchDelete: return .submit
+        case .deleteZipToHankki: return .submit
+        default:
+            return .none
+        }
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Base/BaseViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Base/BaseViewController.swift
@@ -67,6 +67,7 @@ class BaseViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         NetworkService.shared.setupDelegate(self)
     }
     
@@ -91,6 +92,8 @@ extension BaseViewController: BaseViewControllerDelegate {
 private extension BaseViewController {
     // Loading View의 초기 설정을 합니다.
     func setupLoadingView() {
+        NetworkService.shared.setupDelegate(self)
+        
         view.addSubviews(loadingView)
         loadingView.snp.makeConstraints {
             $0.edges.equalToSuperview()

--- a/Hankkijogbo/Hankkijogbo/Present/Base/BaseViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Base/BaseViewController.swift
@@ -12,7 +12,7 @@ import SnapKit
 import Then
 
 protocol BaseViewControllerDelegate: AnyObject {
-    func setLoading(_ isLoading: Bool, type: LoadingViewType)
+    func setupLoading(_ isLoading: Bool, type: LoadingViewType)
 }
 
 /// 모든 UIViewController는 BaseViewController를 상속 받는다.
@@ -56,8 +56,6 @@ class BaseViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         
-        NetworkService.shared.setDelegate(self)
-        
         setupHierarchy()
         setupLayout()
         setupStyle()
@@ -66,6 +64,10 @@ class BaseViewController: UIViewController {
         
         setUpKeyboard()
         hideKeyboard()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        NetworkService.shared.setupDelegate(self)
     }
     
     // MARK: - Set UI
@@ -78,7 +80,7 @@ class BaseViewController: UIViewController {
 }
 
 extension BaseViewController: BaseViewControllerDelegate {
-    func setLoading(_ isLoading: Bool, type: LoadingViewType) {
+    func setupLoading(_ isLoading: Bool, type: LoadingViewType) {
         self.loadingViewType = type
         self.isLoading = isLoading
     }
@@ -97,17 +99,14 @@ private extension BaseViewController {
     
     // Loading State에 맞게 Loading View를 update합니다.
     func updateLoadingView(for type: LoadingViewType) {
-        
-        switch type {
-            
-        case .fullView:
+        switch type {    
+        case .fullView, .submit:
             if isLoading {
-                loadingView.showLoadingView()
+                loadingView.showLoadingView(type)
             } else {
-                loadingView.dismissLoadingView()
+                loadingView.dismissLoadingView(type)
             }
-        case .submit:
-            print("submit loading")
+        
         case .none:
             print("empty loading")
         }

--- a/Hankkijogbo/Hankkijogbo/Present/Base/BaseViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Base/BaseViewController.swift
@@ -39,7 +39,9 @@ class BaseViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .hankkiWhite
+//        view.backgroundColor = .hankkiWhite
+//        view.layer.borderColor = UIColor.red500.cgColor
+//        view.layer.borderWidth = 2
 
         setupHierarchy()
         setupLayout()

--- a/Hankkijogbo/Hankkijogbo/Present/Base/BaseViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Base/BaseViewController.swift
@@ -11,38 +11,53 @@ import Lottie
 import SnapKit
 import Then
 
+protocol BaseViewControllerDelegate: AnyObject {
+    func setLoading(_ isLoading: Bool, type: LoadingViewType)
+}
+
 /// 모든 UIViewController는 BaseViewController를 상속 받는다.
 /// - 각 함수를 override하여 각 VC에 맞게 함수 내용을 작성한다.
 /// - 각 VC에서는 해당 함수들을 호출하지 않아도 된다.
 class BaseViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    private var loadingViewType: LoadingViewType = .none
+    private var isLoading: Bool = false {
+        didSet {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.updateLoadingView(for: self.loadingViewType)
+            }
+        }
+    }
+    
     // MARK: - UI Components
     
-    private let spinner: LottieAnimationView = LottieAnimationView()
-    private let loadingView: UIView = UIView()
+    let loadingView: FullLoadingView = FullLoadingView()
     
     // MARK: - Init
     
     init() {
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - Life Cycle
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-//        view.backgroundColor = .hankkiWhite
-//        view.layer.borderColor = UIColor.red500.cgColor
-//        view.layer.borderWidth = 2
-
+        view.backgroundColor = .white
+        
+        NetworkService.shared.setDelegate(self)
+        
         setupHierarchy()
         setupLayout()
         setupStyle()
@@ -52,7 +67,7 @@ class BaseViewController: UIViewController {
         setUpKeyboard()
         hideKeyboard()
     }
-
+    
     // MARK: - Set UI
     
     func setupHierarchy() { }
@@ -62,51 +77,39 @@ class BaseViewController: UIViewController {
     func setupStyle() { }
 }
 
-private extension BaseViewController {
-    func setupLoadingView() {
-        loadingView.do {
-            $0.isHidden = true
-        }
-        
-        spinner.do {
-            $0.animation = LottieAnimation.named("loading")
-            $0.contentMode = .scaleAspectFill
-            $0.loopMode = .loop
-            $0.stop()
-        }
-        
-        view.addSubview(loadingView)
-        loadingView.addSubview(spinner)
-        
-        loadingView.snp.makeConstraints {
-            $0.edges.equalTo(view.safeAreaLayoutGuide)
-        }
-        
-        spinner.snp.makeConstraints {
-            $0.size.equalTo(68)
-            $0.center.equalToSuperview()
-        }
+extension BaseViewController: BaseViewControllerDelegate {
+    func setLoading(_ isLoading: Bool, type: LoadingViewType) {
+        self.loadingViewType = type
+        self.isLoading = isLoading
     }
 }
 
-extension BaseViewController {
-    func showLoadingView() {
-        loadingView.do {
-            $0.isHidden = false
-        }
-        
-        spinner.do {
-            $0.play()
+
+// Loading View
+private extension BaseViewController {
+    // Loading View의 초기 설정을 합니다.
+    func setupLoadingView() {
+        view.addSubviews(loadingView)
+        loadingView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
     
-    func dismissLoadingView() {
-        loadingView.do {
-            $0.isHidden = true
-        }
+    // Loading State에 맞게 Loading View를 update합니다.
+    func updateLoadingView(for type: LoadingViewType) {
         
-        spinner.do {
-            $0.stop()
+        switch type {
+            
+        case .fullView:
+            if isLoading {
+                loadingView.showLoadingView()
+            } else {
+                loadingView.dismissLoadingView()
+            }
+        case .submit:
+            print("submit loading")
+        case .none:
+            print("empty loading")
         }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -33,8 +33,7 @@ final class CreateZipViewController: BaseViewController {
     private let tagInputTitle = UILabel()
     private let tagInputTextField = TagTextField()
     
-    private lazy var submitButton = MainButton(titleText: StringLiterals.CreateZip.submitButton,
-                                               buttonHandler: submitButtonDidTap)
+    private lazy var submitButton = MainButton(titleText: StringLiterals.CreateZip.submitButton, isValid: false, buttonHandler: submitButtonDidTap)
     
     // MARK: - Life Cycle
     
@@ -112,10 +111,6 @@ final class CreateZipViewController: BaseViewController {
             
             $0.changePlaceholderColor(forPlaceHolder: StringLiterals.CreateZip.TagInput.placeholder,
                                       forColor: .gray400)
-        }
-        
-        submitButton.do {
-            $0.setupDisabledButton()
         }
     }
     
@@ -217,7 +212,7 @@ private extension CreateZipViewController {
     
     func resetTitleTextField() {
         self.titleInputTextField.text = ""
-        submitButton.setupDisabledButton()
+        submitButton.setupIsValid(false)
     }
     
     func dismissSelf() {
@@ -236,9 +231,9 @@ private extension CreateZipViewController {
     
     func isFormValid() {
         if !(titleInputTextField.text ?? "").isEmpty && (tagInputTextField.text ?? "").count > 1 {
-            submitButton.setupEnabledButton()
+            submitButton.setupIsValid(true)
         } else {
-            submitButton.setupDisabledButton()
+            submitButton.setupIsValid(false)
         }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiDetail/View/Cell/HankkiReportOption/HankkiReportOptionFooterView.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiDetail/View/Cell/HankkiReportOption/HankkiReportOptionFooterView.swift
@@ -11,7 +11,7 @@ final class HankkiReportOptionFooterView: BaseCollectionReusableView {
     
     // MARK: - UI Components
     
-    let hankkiReportButton: MainButton = MainButton(titleText: StringLiterals.Common.report, isDisable: true)
+    let hankkiReportButton: MainButton = MainButton(titleText: StringLiterals.Common.report, isValid: false)
     
     // MARK: - Setup UI
     

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiDetail/View/HankkiDetailViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiDetail/View/HankkiDetailViewController.swift
@@ -425,14 +425,14 @@ extension HankkiDetailViewController: UpdateReportButtonStyleDelegate {
         guard let footer = reportOptionCollectionView.collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: HankkiReportOptionFooterView.className, for: IndexPath(item: 3, section: 0)) as? HankkiReportOptionFooterView else { return }
         
         if isEnabled {
-            footer.hankkiReportButton.setupEnabledButton()
+            footer.hankkiReportButton.setupIsValid(true)
             footer.hankkiReportButton.addTarget(
                 self,
                 action: #selector(hankkiReportButtonDidTap),
                 for: .touchUpInside
             )
         } else {
-            footer.hankkiReportButton.setupDisabledButton()
+            footer.hankkiReportButton.setupIsValid(false)
         }
     }
 }


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 로딩뷰를 상황에 맞게 커스텀합니다.


## 🚨 참고 사항

### Moya Plugin 싱글톤화
이전의 `Network Service`에서 각 Service 마다 `Moya Plugin`의 인스턴스를 각각 생성하고 있었습니다.
하지만, network service을 통합적으로 관리하기 위해서 싱글톤을 사용하고 있는데, 각 service 마다 moya plugin을 별도의 객체로 사용하고 있는게 로직상 모순이라고 생각되어, **Moya Plugin 역시 싱글톤**으로 가져가고자합니다.

- 기존의 서비스로직
```swift
private let provider = MoyaProvider<ZipTargetType>(plugins: [MoyaPlugin()])
```

-  바뀐 서비스로직
```swift
private let provider = MoyaProvider<ZipTargetType>(plugins: [MoyaPlugin.shared])
```


## 🖥️ 주요 코드 설명
- Base View Controller 에 `isLaoding` property를 추가
BaseViewControllerDelegate의 setupLoading로직을 통해 MoyaPlugin 에서 **로딩 상태를 관리**합니다.

- Loading View Type
`full view` : 로딩 뷰를 전체적으로 보여줍니다. (로딩 스피너 포함)
`submit` : 제출후, 제출 버튼이 한번 더 눌리지 않도록 화면 전체에 투명한 view를 띄웁니다.
`none` : 특정한 로딩을 띄울 필요가 없을 경우 지정합니다.

`Targe Type`에서 loading view type을 별도로 관리합니다. 추후 확장성을 위해 타입을 추가할 수 있습니다.

- isLoading didSet
isLoading 의 상태가 바뀌면, `LoadingType`에 맞는 적절한 로딩을 띄우고, 제거합니다.

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #222
