### PR TITLE
[Fix] #226 - Apple Login 유효성 검증

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Application/AppDelegate.swift
+++ b/Hankkijogbo/Hankkijogbo/Application/AppDelegate.swift
@@ -28,5 +28,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
 }

--- a/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
+++ b/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
@@ -13,11 +13,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        //
-        
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         window = UIWindow(windowScene: windowScene)
@@ -26,10 +21,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
     
     func sceneDidBecomeActive(_ scene: UIScene) {
@@ -37,19 +28,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
     
     func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
     }
     
     func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
     }
     
 }
@@ -68,7 +52,6 @@ private extension SceneDelegate {
                 print("🛠️ RESTART APPLICATION 🛠️ - NO ACCESS")
                 UIApplication.resetApp()
                 return
-                
             }
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
+++ b/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
@@ -59,13 +59,13 @@ private extension SceneDelegate {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let userId: String = UserDefaults.standard.getUserId()
         
-        appleIDProvider.getCredentialState(forUserID: userId) { (credentialState, error) in
+        appleIDProvider.getCredentialState(forUserID: userId) { (credentialState, _) in
             switch credentialState {
             case .authorized:
                 return
                 
             default:
-                print("사용자가 애플 계정에 로그인하지 않은 상태이거나 인증이 취소되었습니다.")
+                print("🛠️ RESTART APPLICATION 🛠️ - NO ACCESS")
                 UIApplication.resetApp()
                 return
                 

--- a/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
+++ b/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import AuthenticationServices
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
@@ -15,9 +16,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        //
         
         guard let windowScene = (scene as? UIWindowScene) else { return }
-      
+        
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = SplashViewController()
         window?.makeKeyAndVisible()
@@ -31,8 +33,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        checkAppleAccountStatus()
     }
     
     func sceneWillResignActive(_ scene: UIScene) {
@@ -50,5 +51,25 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
+    
+}
 
+private extension SceneDelegate {
+    func checkAppleAccountStatus() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let userId: String = UserDefaults.standard.getUserId()
+        
+        appleIDProvider.getCredentialState(forUserID: userId) { (credentialState, error) in
+            switch credentialState {
+            case .authorized:
+                return
+                
+            default:
+                print("사용자가 애플 계정에 로그인하지 않은 상태이거나 인증이 취소되었습니다.")
+                UIApplication.resetApp()
+                return
+                
+            }
+        }
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UserDefaults+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UserDefaults+.swift
@@ -8,6 +8,17 @@
 import Foundation
 
 extension UserDefaults {
+    func saveUserId(_ userId: String) {
+        UserDefaults.standard.set(userId, forKey: UserDefaultsKey.userId.rawValue)
+    }
+    
+    func removeUserId() {
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKey.userId.rawValue)
+    }
+    
+    func getUserId() -> String {
+        return UserDefaults.standard.string(forKey: UserDefaultsKey.userId.rawValue) ?? ""
+    }
     
     /// refresh, access token 관련 함수
     func saveTokens(accessToken: String, refreshToken: String) {
@@ -62,6 +73,7 @@ extension UserDefaults {
     }
     
     func removeUserInformation() {
+        removeUserId()
         removeTokens()
         removeUniversity()
         removeNickname()
@@ -71,6 +83,7 @@ extension UserDefaults {
 enum UserDefaultsKey: String {
     case accessToken
     case refreshToken
+    case userId
     case university
     case nickname
 }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
@@ -80,9 +80,7 @@ private extension NetworkResult {
                 // access token을 재발급 받는 중 error가 났을 경우
                 // refresh token이 정상적이지 않을 경우
                 // 로그인을 다시 진행해 refresh token을 재발급 받는다.
-                print("🛠️ RESET APPLICATION 🛠️\n\n")
                 UIApplication.resetApp()
-                UIApplication.showBlackToast(message: StringLiterals.Toast.accessError)
             }
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -243,7 +243,7 @@ private extension CreateZipViewController {
 extension CreateZipViewController: UITextFieldDelegate {
     func textFieldDidBeginEditing(_ textField: UITextField) {
         textField.layer.borderColor = UIColor.gray600.cgColor
-        textField.layer.borderWidth = 1.5
+        textField.layer.borderWidth = 2
         
         switch textField.tag {
         case 0:

--- a/Hankkijogbo/Hankkijogbo/Present/Login/View/LoginViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Login/View/LoginViewController.swift
@@ -133,6 +133,9 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
             
             let postLoginRequest: PostLoginRequestDTO = PostLoginRequestDTO(name: fullNameString)
             
+            let userId = appleIDCredential.user
+            UserDefaults.standard.saveUserId(userId)
+            
             viewModel.postLogin(accessToken: identityTokenString, postLoginRequest: postLoginRequest)
             
         default:


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- apple login 유효성을 Scene이 활성화 될 때마다 검증합니다.

## 🖥️ 주요 코드 설명
- SceneDelegate.swift
```swift
    func sceneDidBecomeActive(_ scene: UIScene) {
        checkAppleAccountStatus()
    }
    
        func checkAppleAccountStatus() {
        let appleIDProvider = ASAuthorizationAppleIDProvider()
        let userId: String = UserDefaults.standard.getUserId()
        
        appleIDProvider.getCredentialState(forUserID: userId) { (credentialState, _) in
            switch credentialState {
            case .authorized:
                return
                
            default:
                print("🛠️ RESTART APPLICATION 🛠️ - NO ACCESS")
                UIApplication.resetApp()
                return
            }
        }
    }
```
Scene이 다시 Active 되면, user의 apple Id를 조회하여 가입 여부를 판별합니다.
userId를 가지고 있는데, (로그인 한 상태) 정상 조회가 되지 않은 경우, 앱을 초기화합니다.
이를 통해 앱이 아닌 외부에서 한끼 sever를 탈퇴한 경우에 **앱을 종료하고, 다시 로그인을 유도하거나, 회원가입을 유도하여**대응합니다.


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #226
