### PR TITLE
[Fix] #242 - 디자인 실시간 QA 및 이미지 압축 로직 변경

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Global/Utils/ImageCompressor.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Utils/ImageCompressor.swift
@@ -15,10 +15,6 @@ struct ImageCompressor {
         completion: @escaping (Data?) -> Void
     ) {
         DispatchQueue.global(qos: .userInitiated).async {
-            if image.jpegData(compressionQuality: 0.0)?.count ?? 0 > literalFor1MB {
-                return completion(nil)
-            }
-            
             var compression: CGFloat = 1.0
             var data: Data? = image.jpegData(compressionQuality: compression)
             guard let initialImageSize = data?.count else { return completion(nil) }
@@ -27,6 +23,10 @@ struct ImageCompressor {
             while data != nil && imageSize > maxByte && compression > 0.0 {
                 let percentageToDecrease = getPercentageToDecreaseTo(imageSize: imageSize)
                 compression -= percentageToDecrease
+                if compression < 0.0 {
+                    completion(nil)
+                    return
+                }
                 data = image.jpegData(compressionQuality: compression)
                 imageSize = data?.count ?? 0
             }

--- a/Hankkijogbo/Hankkijogbo/Present/MyZipList/View/MyZipListBottomSheetViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/MyZipList/View/MyZipListBottomSheetViewController.swift
@@ -185,8 +185,6 @@ private extension MyZipListBottomSheetViewController {
         }
         
         viewModel.showAddToZipCompleteToast = { [self] in
-            guard let data = viewModel.myZipListFavoriteData else { return }
-            
             NotificationCenter.default.post(Notification(name: NSNotification.Name(StringLiterals.NotificationName.updateAddToMyZipList)))
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Present/MyZipList/View/MyZipListBottomSheetViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/MyZipList/View/MyZipListBottomSheetViewController.swift
@@ -184,7 +184,7 @@ private extension MyZipListBottomSheetViewController {
                             primaryButtonText: StringLiterals.Alert.check)
         }
         
-        viewModel.showAddToZipCompleteToast = { [self] in
+        viewModel.showAddToZipCompleteToast = {
             NotificationCenter.default.post(Notification(name: NSNotification.Name(StringLiterals.NotificationName.updateAddToMyZipList)))
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Present/MyZipList/ViewModel/MyZipViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/MyZipList/ViewModel/MyZipViewModel.swift
@@ -34,7 +34,7 @@ final class MyZipViewModel {
     func postHankkiToZipAPI(request: PostHankkiToZipRequestDTO, completion: @escaping (() -> Void)) {
         NetworkService.shared.zipService.postHankkiToZip(requestBody: request) { result in
             result.handleNetworkResult { [weak self] _ in
-//                self?.showAddToZipCompleteToast?()
+                self?.showAddToZipCompleteToast?()
                 SetAmplitude.shared.buttonClicked("Jokbo-Add")
                 completion()
             }

--- a/Hankkijogbo/Hankkijogbo/Present/Report/Complete/ReportCompleteViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Report/Complete/ReportCompleteViewController.swift
@@ -11,6 +11,7 @@ final class ReportCompleteViewController: BaseViewController {
     
     // MARK: - Properties
     
+    var isFirst: Bool = true
     let hankkiId: Int
     let reportedNumber: Int
     var nickname: String {
@@ -72,7 +73,10 @@ final class ReportCompleteViewController: BaseViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
-        setupBottomGradientView()
+        if isFirst {
+            setupBottomGradientView()
+            isFirst = false
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -111,7 +115,7 @@ final class ReportCompleteViewController: BaseViewController {
             $0.leading.equalTo(reportedNumberLabel)
         }
         hankkiImageView.snp.makeConstraints {
-            $0.top.equalTo(randomThanksLabel.snp.bottom).offset(UIScreen.convertByHeightRatio(103))
+            $0.top.equalTo(reportedNumberLabel.snp.bottom).offset(UIScreen.convertByHeightRatio(131))
             $0.centerX.equalToSuperview()
             $0.width.equalTo(UIScreen.convertByWidthRatio(312))
             $0.height.equalTo(UIScreen.convertByHeightRatio(372))
@@ -123,7 +127,7 @@ final class ReportCompleteViewController: BaseViewController {
         }
         bottomGradientView.snp.makeConstraints {
             $0.horizontalEdges.bottom.equalToSuperview()
-            $0.height.equalTo(UIScreen.convertByHeightRatio(374))
+            $0.height.equalTo(UIScreen.convertByHeightRatio(385))
         }
         hankkiInfoCardView.snp.makeConstraints {
             $0.bottom.equalTo(bottomButtonView.snp.top).offset(-50)

--- a/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/ReportCompositionalLayoutFactory.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/ReportCompositionalLayoutFactory.swift
@@ -84,7 +84,7 @@ extension ReportCompositionalLayoutFactory {
         let item = createItem(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(95))
         let group = createGroup(item: [item], widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(95))
         let section = createLayoutSection(group: group, sectionContentInsets: .init(top: 0, leading: 22, bottom: 0, trailing: 14))
-        section.interGroupSpacing = 10
+        section.interGroupSpacing = 4
         return section
     }
     
@@ -94,7 +94,7 @@ extension ReportCompositionalLayoutFactory {
         let footer = createBoundarySupplementaryItem(type: .footer, widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(80), alignment: .bottom)
         let item = createItem(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(32))
         let group = createGroup(item: [item], widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(32))
-        let section = createLayoutSection(group: group, sectionContentInsets: .init(top: 24, leading: 14, bottom: 52, trailing: 22), boundarySupplementaryItems: [footer])
+        let section = createLayoutSection(group: group, sectionContentInsets: .init(top: 8, leading: 14, bottom: 52, trailing: 22), boundarySupplementaryItems: [footer])
         return section
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/ReportViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/ReportViewController.swift
@@ -70,7 +70,7 @@ final class ReportViewController: BaseViewController {
     
     override func setupLayout() {
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(18)
+            $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
         }

--- a/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/SearchBarCollectionViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Report/ReportMain/View/SearchBarCollectionViewCell.swift
@@ -96,6 +96,7 @@ private extension SearchBarCollectionViewCell {
     // MARK: - Private Func
     
     func setupStyleForNotSet() {
+        reportedNumberLabel.textColor = .red500
         searchBarButton.do {
             $0.backgroundColor = .gray100
             $0.layer.cornerRadius = 10
@@ -112,6 +113,7 @@ private extension SearchBarCollectionViewCell {
     }
     
     func setupStyleForSet() {
+        reportedNumberLabel.textColor = .gray600
         searchBarButton.do {
             $0.backgroundColor = .red100
             $0.layer.cornerRadius = 10


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
### 1. 디자인 실시간 QA를 진행했습니다 with 윤정양
- 제보하기 상단 오프셋 제거
- 식당 선택 시 제보수 label 색 변경
- 다른 족보에도 추가 뜨게 주석 해제
- 제보 완료 화면 gradient 최초 1번만 적용되게 수정
- 제보하기 메뉴 간격 수정
### 2. 이미지 업로드 이슈를 압축 로직을 수정하여 해결했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 이거 pull 받고 이미지 안 되던 거 다 해봐주세요! @shimseohyun (가현양은 다 되는 거 확인했습니다)


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`ReportCompleteViewController`
- `setupBottomGradientView`가 `viewDidLayoutSubviews` 안에 있어서 계속 그라디언트가 중첩되어 그려지는 이슈가 있었습니다.
- 그런데 이걸 `viewDidLayoutSubviews`가 아닌 곳으로 옮기자니, 그라디언트는 여기서만 그려질 수 있다고 하더라구요.
- 그래서 제보 완료 화면 처음 나올 때 즉 최초에만 그라디언트뷰를 그리도록 if문을 추가했습니다.
```swift
// MARK: - Properties

var isFirst: Bool = true

// 생략 ...

override func viewDidLayoutSubviews() {
        super.viewDidLayoutSubviews()

        if isFirst {
            setupBottomGradientView()
            isFirst = false
        }
}
```

`ImageCompressor`
- 변경 전
- 원래는 while문에 들어가기 전에, if문에서 0.0(= 최대 압축율)으로 압축을 해도 1MB를 넘는다면 바로 nil을 보내서 Alert를 띄우는 방식이었습니다. (이 조건문이 불필요한 while loop를 줄여줄 것이라고 생각했기 때문)
- 하지만 서현양과 로그를 찍어보면서 해당 로직이 맞지 않는 것 같다는 것을 확인했습니다. (ex. 4.3MB는 해당 if문에 걸리지 않는데, 1.9MB는 해당 if문에 걸리는 사건)
```swift
DispatchQueue.global(qos: .userInitiated).async {
    // 이 if문이 삭제됨 !!
    if image.jpegData(compressionQuality: 0.0)?.count ?? 0 > literalFor1MB {
        return completion(nil) // 원래는 0.0으로 최대 압축으로 바로 해서 성공, 실패를 판단했음 -> 해당 로직이 맞지 않는다는 것을 확인함
    }

    var compression: CGFloat = 1.0
    var data: Data? = image.jpegData(compressionQuality: compression)
    guard let initialImageSize = data?.count else { return completion(nil) }
    var imageSize: Int = initialImageSize
            
    while data != nil && imageSize > maxByte && compression > 0.0 {
        let percentageToDecrease = getPercentageToDecreaseTo(imageSize: imageSize)
        compression -= percentageToDecrease
        data = image.jpegData(compressionQuality: compression)
        imageSize = data?.count ?? 0
    }
            
    completion(data)
}
```

- 변경 후
- 그래서 해당 if문을 지우고, 그냥 1.0부터 압축율을 줄여가며 while문을 계속 돌다가. 압축율이 마이너스가 됐을 때 nil을 반환하는 방식으로 변경했습니다.
- 압축율이 마이너스가 됐다는 것은 0.0~1.0 내에서 맞는 압축율이 없을 때를 의미하기 때문입니다.
```swift
DispatchQueue.global(qos: .userInitiated).async {
    var compression: CGFloat = 1.0
    var data: Data? = image.jpegData(compressionQuality: compression)
    guard let initialImageSize = data?.count else { return completion(nil) }
    var imageSize: Int = initialImageSize
            
    while data != nil && imageSize > maxByte && compression > 0.0 {
        let percentageToDecrease = getPercentageToDecreaseTo(imageSize: imageSize)
        compression -= percentageToDecrease
        // 이 if문이 추가됨 !!
        if compression < 0.0 { // -> 1.0부터 0.0 될 때까지 while 돌았는데 맞는 압축률을 찾지 못해서 음수가 된 경우 !
            completion(nil) // 압축 실패 Alert 창 띄우기
            return
        }
        data = image.jpegData(compressionQuality: compression)
        imageSize = data?.count ?? 0
    }
            
    completion(data)
}
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #242 
