### PR TITLE
[Fix] #249 - Hankki List Cell Chips 짤리는 문제 해결

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/Cell/HankkiListTableViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/Cell/HankkiListTableViewCell.swift
@@ -135,7 +135,6 @@ final class HankkiListTableViewCell: BaseTableViewCell {
         self.contentView.addSubviews(cellStackView, line)
         cellStackView.addArrangedSubviews(thumbnailView, infoStackView, heartButton)
         infoStackView.addArrangedSubviews(titleStaciView, subInfoStackView)
-        titleStaciView.addArrangedSubviews(titleLabel, categoryChipView)
         subInfoStackView.addArrangedSubviews(createSubInfoView(0), createSubInfoView(1))
         categoryChipView.addSubview(categoryLabel)
     }
@@ -174,10 +173,13 @@ final class HankkiListTableViewCell: BaseTableViewCell {
 extension HankkiListTableViewCell {
     func dataBind(_ data: Model, isFinal: Bool, isLikeButtonDisable: Bool) {
         self.data = data
-
-        titleLabel.text = data.name
-        thumbnailView.setKFImage(url: data.imageURL, placeholder: .imgDetailDefault)
+        
+        // 이래야 categoryLabel 크기가 유지됩니다.
         categoryLabel.text = data.category
+        titleLabel.text = data.name
+        titleStaciView.addArrangedSubviews(titleLabel, categoryChipView)
+        
+        thumbnailView.setKFImage(url: data.imageURL, placeholder: .imgDetailDefault)
         heartButton.isHidden = isLikeButtonDisable
         priceLabel.formattingPrice(price: data.lowestPrice)
         heartCountLabel.text = "\(data.heartCount)"


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
 Hankki List Cell Chips 짤리는 문제 해결했습니다.
![Screenshot 2024-08-28 at 2 35 42 PM](https://github.com/user-attachments/assets/4f9a9c06-d57f-40b4-9475-baa0fce2ba26)

## 🖥️ 주요 코드 설명
특정 device에서 `setContentCompressionResistancePriority`이 우선 적용되지 않는 것을 확인했습니다.
dataBind 할 때마다 우선 순위가 무시되어, data bind 할 때마다 stackView를 리로딩하여 Chips 가 잘리지 않도록 설정합니다.


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #249
