### PR TITLE
[Feat] #269 - 둘러보기 로그인유저 식별 로직 추가

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
@@ -223,4 +223,8 @@ enum StringLiterals {
         static let OneonOne = "https://tally.so/r/mO0oJY"
         static let Terms = "https://fast-kilometer-dbf.notion.site/FAQ-bb4d74b681d14f4f91bbbcc829f6d023?pvs=4"
     }
+    
+    enum Onboarding {
+        static let guest = "둘러보기"
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UserDefaults+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UserDefaults+.swift
@@ -8,6 +8,12 @@
 import Foundation
 
 extension UserDefaults {
+    /// 유저의 로그인 유무를 확인합니다.
+    /// UserDefaults에 AccessToken이 저장되어있을 경우 로그인이 되어있다고 판단합니다.
+    var isLogin: Bool {
+        return !UserDefaults.standard.getAccesshToken().isEmpty
+    }
+    
     func saveUserId(_ userId: String) {
         UserDefaults.standard.set(userId, forKey: UserDefaultsKey.userId.rawValue)
     }

--- a/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
@@ -59,29 +59,34 @@ extension BaseTargetType {
     
     var headers: [String: String]? {
         var header: [String: String] = [:]
+        
         switch headerType {
         case .loginHeader(let accessToken):
             header["Content-Type"] = "application/json"
             header["Authorization"] = "\(accessToken)"
-            
-        case .withdrawHeader(let authorizationCode):
-            header["Content-Type"] = "application/json"
-            let accessToken = UserDefaults.standard.getAccesshToken()
-            header["Authorization"] = URLConstant.bearer + "\(accessToken)"
-            header["X-Apple-Code"] = "\(authorizationCode)"
+            return header
             
         case .refreshTokenHeader:
             header["Content-Type"] = "application/json"
             let refreshToken = UserDefaults.standard.getRefreshToken()
             header["Authorization"] = URLConstant.bearer + "\(refreshToken)"
+            return header
             
+        // 이후부터는 access token이 헤더에 필요합니다.
+        case .withdrawHeader(let authorizationCode):
+            header["Content-Type"] = "application/json"
+            header["X-Apple-Code"] = "\(authorizationCode)"
+               
         case .formdataHeader:
             header["Content-Type"] = "multipart/form-data"
-            let accessToken = UserDefaults.standard.getAccesshToken()
-            header["Authorization"] = URLConstant.bearer + "\(accessToken)"
             
         default:
             header["Content-Type"] = "application/json"
+        }
+        
+        if UserDefaults.standard.isLogin {
+            // 유저가 로그인 한 회원일 경우
+            // Access Token을 header-Authorization 에 삽입해 전송한다.
             let accessToken = UserDefaults.standard.getAccesshToken()
             header["Authorization"] = URLConstant.bearer + "\(accessToken)"
         }
@@ -105,3 +110,4 @@ extension BaseTargetType {
         }
     }
 }
+

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
@@ -56,8 +56,19 @@ extension NetworkResult {
             
         case .unAuthorized:
             // 401 error
-            // access token이 올바르지 않거나, 만료된 경우
-            self.postReissue()
+            if UserDefaults.standard.isLogin {
+                // 로그인을 한 유저인 경우
+                // access token을 재발급 받는다.
+                self.postReissue()
+            } else {
+                // 로그인을 하지 않은 유저인 경우
+                // 로그인이 필요하다는 알럿창을 띄운다 (임시)
+                print("👽 USER IS NOT LOGGED IN👽")
+                UIApplication.showAlert(titleText: "로그인을 해주세요",
+                                        subText: "로그인이 필요한 기능입니다.",
+                                        primaryButtonText: "확인"
+                )
+            }
             
         default:
             UIApplication.showBlackToast(message: StringLiterals.Toast.serverError)

--- a/Hankkijogbo/Hankkijogbo/Present/Login/View/LoginViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Login/View/LoginViewController.swift
@@ -9,10 +9,11 @@ final class LoginViewController: BaseViewController {
     
     // MARK: - UI Components
     
-    let logoImageView: UIImageView = UIImageView()
-    let viewTitle: UILabel = UILabel()
-    let imageView: UIImageView  = UIImageView()
-    let loginButton: UIButton = UIButton()
+    private let guestButton: UIButton = UIButton()
+    private let logoImageView: UIImageView = UIImageView()
+    private let viewTitle: UILabel = UILabel()
+    private let imageView: UIImageView  = UIImageView()
+    private let loginButton: UIButton = UIButton()
     
     // MARK: - Life Cycle
     
@@ -25,10 +26,22 @@ final class LoginViewController: BaseViewController {
     // MARK: - Set UI
     
     override func setupStyle() {
-        
         view.do {
             $0.contentMode = .scaleAspectFill
             $0.backgroundColor = .red500
+        }
+        
+        guestButton.do {
+            $0.setupPadding(top: 8, leading: 8, bottom: 8, trailing: 8)
+            $0.setupBackgroundColor(.clear)
+            
+            let guestAttributedTitle = UILabel.setupAttributedText(
+                for: PretendardStyle.body5,
+                withText: StringLiterals.Onboarding.guest,
+                color: .hankkiWhite
+            )
+            
+            $0.setAttributedTitle(guestAttributedTitle, for: .normal)
         }
         
         logoImageView.do {
@@ -63,10 +76,15 @@ final class LoginViewController: BaseViewController {
     }
     
     override func setupHierarchy() {
-        view.addSubviews(imageView, logoImageView, viewTitle, loginButton)
+        view.addSubviews(guestButton, imageView, logoImageView, viewTitle, loginButton)
     }
     
     override func setupLayout() {
+        guestButton.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(5)
+            $0.trailing.equalToSuperview().inset(14)
+        }
+        
         logoImageView.snp.makeConstraints {
             $0.width.equalTo(180)
             $0.height.equalTo(41)
@@ -95,9 +113,19 @@ final class LoginViewController: BaseViewController {
 
 private extension LoginViewController {
     func setupAction() {
+        guestButton.addTarget(self, action: #selector(guestButtonDidTap), for: .touchUpInside)
         loginButton.addTarget(self, action: #selector(loginButtonDidTap), for: .touchUpInside)
     }
 
+    @objc func guestButtonDidTap() {
+        // 홈화면으로 이동
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            let navigationController = HankkiNavigationController(rootViewController: TabBarController())
+            self.view.window?.rootViewController = navigationController
+            navigationController.popToRootViewController(animated: false)
+        }
+    }
+        
     @objc func loginButtonDidTap() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()

--- a/Hankkijogbo/Hankkijogbo/Present/Splash/SplashViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Splash/SplashViewController.swift
@@ -19,7 +19,7 @@ final class SplashViewController: BaseViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if isLogin() {
+        if UserDefaults.standard.isLogin {
             presentHomeView()
         } else {
             presentLoginView()
@@ -68,10 +68,6 @@ final class SplashViewController: BaseViewController {
 }
 
 private extension SplashViewController {
-    func isLogin() -> Bool {
-        return !UserDefaults.standard.getAccesshToken().isEmpty
-    }
-    
     func presentHomeView() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             let navigationController = HankkiNavigationController(rootViewController: TabBarController())


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 둘러보기 기능을 추가했습니다.


## 🚨 참고 사항
HomeViewModel에서 호출하는 API의 응답 결과 처리를 Network Resault의 handleNetworkResult로 바꿔주세요... 통합적인 에러 핸들링을 위함입니다.

#### 관련 PR
- 네트워크 에러 통합 처리 #154
- reissue 에러 처리 #156

## 📸 스크린샷
|    구현 내용    |   비로그인   |   로그인   |
| :-------------: | :----------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/af3aeccc-eb57-430f-92ba-9646186296c3" width ="250"> | <img src = "https://github.com/user-attachments/assets/64d206dc-2f4f-4630-9fd6-7dfba27e4557" width ="250"> | 

홈 뷰에서 다른 알럿뜨는 이유는 서버 업뎃 안됨 + 위에 참고사항에서 기술한 이유때문입니다.

## 🖥️ 주요 코드 설명
### UserDefaults 의 is Login
```swift
    /// 유저의 로그인 유무를 확인합니다.
    /// UserDefaults에 AccessToken이 저장되어있을 경우 로그인이 되어있다고 판단합니다.
    var isLogin: Bool {
        return !UserDefaults.standard.getAccesshToken().isEmpty
    }
```
Access Token 의 유무로 로그인 여부를 확인합니다.
추후 로그인 여부 확인 방식의 변동이 있을 수 있기 대문에 연산 프로퍼티로 추가해두었습니다.

### Network 로직의 변화
- **Header 값 변경**
```siwft
        if UserDefaults.standard.isLogin {
            // 유저가 로그인 한 회원일 경우
            // Access Token을 header-Authorization 에 삽입해 전송한다.
            let accessToken = UserDefaults.standard.getAccesshToken()
            header["Authorization"] = URLConstant.bearer + "\(accessToken)"
        }
        
        return header
```
유저가 로그인을 한 경우  Authorization 헤더에 accesstoken을 넣어서 보냅니다.  로그인을 하지 않은 경우는 Authorization 헤더 자체를 보내지 않습니다.

- **401 error handeling 변경**

```swift
        case .unAuthorized:
            // 401 error
            if UserDefaults.standard.isLogin {
                // 로그인을 한 유저인 경우
                // access token을 재발급 받는다.
                self.postReissue()
            } else {
                // 로그인을 하지 않은 유저인 경우
                // 로그인이 필요하다는 알럿창을 띄운다 (임시)
                print("👽 USER IS NOT LOGGED IN👽")
                UIApplication.showAlert(titleText: "로그인을 해주세요",
                                        subText: "로그인이 필요한 기능입니다.",
                                        primaryButtonText: "확인"
                )
            }
```

401의 경우, 로그인한 유저는 access token이 만료되었을떄, 비로그인한 유저는 접근 권한이 없을때 반환되도록 수정되었습니다. 이에 맞게 401 에러코드를 전달받으면 그에 맞는 방식으로 에러를 처리합니다

**현재 비로그인 alert 창의 경우 제가 임의로 테스트하기위해 넣어두었습니다.** 
이후담당자가 수정해주시면 됩니다.



## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가? (`main` 브랜치 맞죠?)
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #이슈번호
