### PR TITLE
[Fix] #292 - Home filtering, total list 초기화 방지 에러

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
@@ -198,26 +198,12 @@ extension HomeViewController {
 }
 
 private extension HomeViewController {
-    func loadInitialData() {
-        universityId = UserDefaults.standard.getUniversity()?.id
-        viewModel.getHankkiListAPI(universityId: universityId, storeCategory: "", priceCategory: "", sortOption: "") { [weak self] success in
-            let isEmpty = self?.viewModel.hankkiLists.isEmpty ?? true
-            self?.viewModel.onHankkiListFetchCompletion?(success, isEmpty)
-        }
-        viewModel.getHankkiPinAPI(universityId: universityId, storeCategory: "", priceCategory: "", sortOption: "", completion: { _ in })
-    }
-    
     func updateUniversityData() {
         let universityId = UserDefaults.standard.getUniversity()?.id
         
-        viewModel.getHankkiListAPI(universityId: universityId, storeCategory: "", priceCategory: "", sortOption: "") { [weak self] success in
-            let isEmpty = self?.viewModel.hankkiLists.isEmpty ?? true
-            self?.viewModel.onHankkiListFetchCompletion?(success, isEmpty)
-        }
-        viewModel.getHankkiPinAPI(universityId: universityId, storeCategory: "", priceCategory: "", sortOption: "", completion: { _ in })
-        rootView.bottomSheetView.totalListCollectionView.reloadData()
+        viewModel.updateHankkiList()
         
-        // 대학 선택 후 홈화면 재진입 시 해당 대학교에 맞게 reset
+        rootView.bottomSheetView.totalListCollectionView.reloadData()
         hideMarkerInfoCard()
         rootView.bottomSheetView.viewLayoutIfNeededWithDownAnimation()
     }


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- Error Fix


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`HomeViewController`
- viewWillAppear 시 updateUniversityData에서 식당 리스트, 장소 핀 정보를 가져오는 API를 초기화해서 재호출 하는 부분을 ViewModel의 updateHankkiList를 호출하게 변경함 
```swift
func updateUniversityData() {
        let universityId = UserDefaults.standard.getUniversity()?.id
        
        viewModel.updateHankkiList()
        
        rootView.bottomSheetView.totalListCollectionView.reloadData()
        hideMarkerInfoCard()
        rootView.bottomSheetView.viewLayoutIfNeededWithDownAnimation()
    }
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #292 
