### PR TITLE
[Fix] #300 - 2차 스프린트 최종 QA 반영

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
@@ -129,10 +129,10 @@ extension TabBarController: UITabBarControllerDelegate {
         }
         
         if !UserDefaults.standard.isLogin {
-            self.showAlert(titleText: "로그인이 필요한 기능이에요.",
-                           secondaryButtonText: "닫기",
-                           primaryButtonText: "로그인하기",
-                           primaryButtonHandler: {UIApplication.browseApp()})
+            self.showAlert(titleText: StringLiterals.Alert.Browse.title,
+                           secondaryButtonText: StringLiterals.Alert.Browse.secondaryButton,
+                           primaryButtonText: StringLiterals.Alert.Browse.primaryButton,
+                           primaryButtonHandler: { UIApplication.browseApp() })
         } else {
             return true
         }

--- a/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
@@ -128,6 +128,14 @@ extension TabBarController: UITabBarControllerDelegate {
             return false
         }
         
-        return true
+        if !UserDefaults.standard.isLogin {
+            self.showAlert(titleText: "로그인이 필요한 기능이에요.",
+                           secondaryButtonText: "닫기",
+                           primaryButtonText: "로그인하기",
+                           primaryButtonHandler: {UIApplication.browseApp()})
+        } else {
+            return true
+        }
+        return false
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
@@ -100,6 +100,13 @@ private extension TabBarController {
         
         return currentViewController
     }
+    
+    func showRequireLoginAlert() {
+        self.showAlert(titleText: StringLiterals.Alert.Browse.title,
+                       secondaryButtonText: StringLiterals.Alert.Browse.secondaryButton,
+                       primaryButtonText: StringLiterals.Alert.Browse.primaryButton,
+                       primaryButtonHandler: { UIApplication.browseApp() })
+    }
 }
 
 /// Custom Tab Bar
@@ -116,26 +123,29 @@ final class CustomTabBar: UITabBar {
 extension TabBarController: UITabBarControllerDelegate {
     
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
-
         guard let index = viewControllers?.firstIndex(of: viewController) else { return true }
         
         let tabBarItem = TabBarItem.allCases[index]
         SetupAmplitude.shared.logEvent(tabBarItem.amplitudeButtonName)
         
+        let isNotLogin: Bool = !UserDefaults.standard.isLogin
+        let isAllUniversity: Bool = (UserDefaults.standard.getUniversity()?.id == nil)
+        
         switch tabBarItem {
         case .report:
-            if UserDefaults.standard.getUniversity()?.id == nil {
-                self.showAlert(titleText: StringLiterals.Alert.selectUniversityFirst, primaryButtonText: StringLiterals.Alert.check)
+            if isNotLogin {
+                showRequireLoginAlert()
             } else {
-                navigationController?.pushViewController(TabBarItem.report.targetViewController, animated: true)
+                if isAllUniversity {
+                    self.showAlert(titleText: StringLiterals.Alert.selectUniversityFirst, primaryButtonText: StringLiterals.Alert.check)
+                } else {
+                    navigationController?.pushViewController(TabBarItem.report.targetViewController, animated: true)
+                }
             }
             return false
         case .mypage:
-            if !UserDefaults.standard.isLogin {
-                self.showAlert(titleText: StringLiterals.Alert.Browse.title,
-                               secondaryButtonText: StringLiterals.Alert.Browse.secondaryButton,
-                               primaryButtonText: StringLiterals.Alert.Browse.primaryButton,
-                               primaryButtonHandler: { UIApplication.browseApp() })
+            if isNotLogin {
+                showRequireLoginAlert()
                 return false
             }
             return true

--- a/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarController.swift
@@ -31,6 +31,7 @@ final class TabBarController: UITabBarController {
 // MARK: - Private Extensions
 
 private extension TabBarController {
+    
     func setupStyle() {
         view.backgroundColor = .white
         tabBar.backgroundColor = .white
@@ -101,7 +102,7 @@ private extension TabBarController {
     }
 }
 
-// Custom Tab Bar
+/// Custom Tab Bar
 final class CustomTabBar: UITabBar {
     override func sizeThatFits(_ size: CGSize) -> CGSize {
         var size = super.sizeThatFits(size)
@@ -110,7 +111,10 @@ final class CustomTabBar: UITabBar {
     }
 }
 
+// MARK: - UITabBarControllerDelegate
+
 extension TabBarController: UITabBarControllerDelegate {
+    
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
 
         guard let index = viewControllers?.firstIndex(of: viewController) else { return true }
@@ -118,24 +122,25 @@ extension TabBarController: UITabBarControllerDelegate {
         let tabBarItem = TabBarItem.allCases[index]
         SetupAmplitude.shared.logEvent(tabBarItem.amplitudeButtonName)
         
-        if index == TabBarItem.allCases.firstIndex(of: .report) {
+        switch tabBarItem {
+        case .report:
             if UserDefaults.standard.getUniversity()?.id == nil {
                 self.showAlert(titleText: StringLiterals.Alert.selectUniversityFirst, primaryButtonText: StringLiterals.Alert.check)
             } else {
-                let reportViewController = ReportViewController()
-                navigationController?.pushViewController(reportViewController, animated: true)
+                navigationController?.pushViewController(TabBarItem.report.targetViewController, animated: true)
             }
             return false
-        }
-        
-        if !UserDefaults.standard.isLogin {
-            self.showAlert(titleText: StringLiterals.Alert.Browse.title,
-                           secondaryButtonText: StringLiterals.Alert.Browse.secondaryButton,
-                           primaryButtonText: StringLiterals.Alert.Browse.primaryButton,
-                           primaryButtonHandler: { UIApplication.browseApp() })
-        } else {
+        case .mypage:
+            if !UserDefaults.standard.isLogin {
+                self.showAlert(titleText: StringLiterals.Alert.Browse.title,
+                               secondaryButtonText: StringLiterals.Alert.Browse.secondaryButton,
+                               primaryButtonText: StringLiterals.Alert.Browse.primaryButton,
+                               primaryButtonHandler: { UIApplication.browseApp() })
+                return false
+            }
+            return true
+        default:
             return true
         }
-        return false
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/StringLiterals.swift
@@ -57,6 +57,12 @@ enum StringLiterals {
         static let move = "이동하기"
         static let add = "추가하기"
         
+        enum Browse {
+            static let title = "로그인이 필요한 기능이에요."
+            static let secondaryButton = "닫기"
+            static let primaryButton = "로그인하기"
+        }
+        
         enum Logout {
             static let title = "정말 로그아웃 하실 건가요?"
             static let secondaryButton = Common.logout

--- a/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/NetworkResult.swift
@@ -64,9 +64,9 @@ extension NetworkResult {
                 // 로그인을 하지 않은 유저인 경우
                 // 로그인이 필요하다는 알럿창을 띄운다 (임시)
                 print("👽 USER IS NOT LOGGED IN👽")
-                UIApplication.showAlert(titleText: "로그인이 필요한 기능이에요. ",
-                                        secondaryButtonText: "닫기",
-                                        primaryButtonText: "로그인하기",
+                UIApplication.showAlert(titleText: StringLiterals.Alert.Browse.title,
+                                        secondaryButtonText: StringLiterals.Alert.Browse.secondaryButton,
+                                        primaryButtonText: StringLiterals.Alert.Browse.primaryButton,
                                         primaryButtonHandler: {
                     if let delegate = delegate {
                         delegate.moveToLoginScreen()

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiMenu/View/Edit/Cell/EditMenuCollectionViewCell.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiMenu/View/Edit/Cell/EditMenuCollectionViewCell.swift
@@ -62,6 +62,9 @@ final class EditMenuCollectionViewCell: BaseCollectionViewCell {
                 color: .gray700
             )
         }
+        radioButton.do {
+            $0.isUserInteractionEnabled = false
+        }
     }
     
     func updateStyle(isSelected: Bool) {

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
@@ -171,17 +171,6 @@ extension HomeViewController {
         navigationController?.pushViewController(univSelectViewController, animated: true)
     }
     
-    func showLoginAlert() {
-        showAlert(titleText: "로그인이 필요한 기능이에요. ",
-                  secondaryButtonText: "닫기",
-                  primaryButtonText: "로그인하기",
-                  primaryButtonHandler: moveToLogin)
-    }
-    
-    func moveToLogin() {
-        // TODO: - Login 이동
-    }
-    
     @objc func presentMyZipBottomSheet() {
         guard let thumbnailData = viewModel.hankkiThumbnail else { return }
         self.presentMyZipListBottomSheet(id: thumbnailData.id)


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 업데이트 당일 최종 QA 발생!
- 셀 안의 라디오 버튼 클릭 시 셀 클릭이 안 먹는다는 이슈를 해결했어요. (버튼 클릭을 무시하는 방식 사용)
- 둘러보기 시 마이페이지 탭의 접근을 막았어요.
- 추가적으로, **둘러보기일 때 제보하기 탭 클릭 시** 대학교 선택해 달라는 Alert가 뜨길래 이를 로그인 하라는 것으로 변경했고, 홈 탭바 클릭 시에도 Alert가 뜨길래 이를 막았습니다.
- `TabBarController` 쪽 코드 개선을 진행했어요. 로직을 더 알아보기 쉽게끔 했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 원래 `TabBarController` 코드를 제가 짰던 게 아니라서, 고친 부분 괜찮으신지 확인 부탁드려요.

## 📸 스크린샷
|    구현 내용    |   둘러보기일 때 제보하기 탭, 마이페이지 탭 클릭 시 Alert   |  
| :-------------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/944ceb21-0512-4c8d-8253-0fd968dafccd" width ="250"> |


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`TabBarController`
- 반복되거나 알아보기 힘든 `Bool` 값을 변수로 지정해 간소화
- `tabBarItem`을 기준으로 `case`를 나눠 분기 처리
```swift
let isNotLogin: Bool = !UserDefaults.standard.isLogin
let isAllUniversity: Bool = (UserDefaults.standard.getUniversity()?.id == nil)

switch tabBarItem {
case .report:
    if isNotLogin {
        showRequireLoginAlert()
    } else {
        if isAllUniversity {
            self.showAlert(titleText: StringLiterals.Alert.selectUniversityFirst, primaryButtonText: StringLiterals.Alert.check)
        } else {
            navigationController?.pushViewController(TabBarItem.report.targetViewController, animated: true)
        }
    }
    return false
case .mypage:
    if isNotLogin {
        showRequireLoginAlert()
        return false
    }
    return true
default:
    return true
}
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #300 
