### PR TITLE
[Refactor] #288 - CreateZipTextField - Component 생성

### DIFF
--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		86B761232C3EC87A00413059 /* ZipListCollectionViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B761222C3EC87A00413059 /* ZipListCollectionViewCellModel.swift */; };
 		86B761302C3EEDEE00413059 /* HankkiListViewControllerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B7612F2C3EEDEE00413059 /* HankkiListViewControllerType.swift */; };
 		86BD76092D0309CE0070EC5D /* CreateZipTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86BD76082D0309CE0070EC5D /* CreateZipTextField.swift */; };
+		86BD760B2D033E7E0070EC5D /* CreateZipTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86BD760A2D033E7E0070EC5D /* CreateZipTextFieldType.swift */; };
 		86E78D1D2C46B67400BE0DC3 /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E78D1B2C46B67400BE0DC3 /* EmptyView.swift */; };
 		86FAFBAD2CB4DECE00910A7D /* MypageSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FAFBAC2CB4DECE00910A7D /* MypageSeparatorView.swift */; };
 		9E38C1F6B1DB0B110CF9BCB7 /* Pods_Hankkijogbo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AC84CE15CCD6BBF6F508B9D /* Pods_Hankkijogbo.framework */; };
@@ -363,6 +364,7 @@
 		86B761222C3EC87A00413059 /* ZipListCollectionViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipListCollectionViewCellModel.swift; sourceTree = "<group>"; };
 		86B7612F2C3EEDEE00413059 /* HankkiListViewControllerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HankkiListViewControllerType.swift; sourceTree = "<group>"; };
 		86BD76082D0309CE0070EC5D /* CreateZipTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateZipTextField.swift; sourceTree = "<group>"; };
+		86BD760A2D033E7E0070EC5D /* CreateZipTextFieldType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateZipTextFieldType.swift; sourceTree = "<group>"; };
 		86E78D1B2C46B67400BE0DC3 /* EmptyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
 		86FAFBAC2CB4DECE00910A7D /* MypageSeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSeparatorView.swift; sourceTree = "<group>"; };
 		A2079B932C656F7D00817651 /* ImageCompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCompressor.swift; sourceTree = "<group>"; };
@@ -1254,6 +1256,7 @@
 			isa = PBXGroup;
 			children = (
 				86BD76082D0309CE0070EC5D /* CreateZipTextField.swift */,
+				86BD760A2D033E7E0070EC5D /* CreateZipTextFieldType.swift */,
 			);
 			path = CreateZipTextField;
 			sourceTree = "<group>";
@@ -1877,6 +1880,7 @@
 				864FA9122C3D34B80051EA36 /* MypageCollectionViewCellEnum.swift in Sources */,
 				A2B599182C39B5C8004B7E4E /* BlackToastView.swift in Sources */,
 				A2AF6FF32CEB5EF800F5271D /* HankkiAccessoryView.swift in Sources */,
+				86BD760B2D033E7E0070EC5D /* CreateZipTextFieldType.swift in Sources */,
 				8302F8E12C3DB43D004ADAA4 /* TotalListBottomSheetView.swift in Sources */,
 				A28F60482CB877B6000FDCD2 /* EditMenuViewModel.swift in Sources */,
 				8302F8DD2C3D6C0B004ADAA4 /* (null) in Sources */,

--- a/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
+++ b/Hankkijogbo/Hankkijogbo.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		86B761212C3DF60800413059 /* ZipHeaderTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B761202C3DF60800413059 /* ZipHeaderTableView.swift */; };
 		86B761232C3EC87A00413059 /* ZipListCollectionViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B761222C3EC87A00413059 /* ZipListCollectionViewCellModel.swift */; };
 		86B761302C3EEDEE00413059 /* HankkiListViewControllerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B7612F2C3EEDEE00413059 /* HankkiListViewControllerType.swift */; };
+		86BD76092D0309CE0070EC5D /* CreateZipTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86BD76082D0309CE0070EC5D /* CreateZipTextField.swift */; };
 		86E78D1D2C46B67400BE0DC3 /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E78D1B2C46B67400BE0DC3 /* EmptyView.swift */; };
 		86FAFBAD2CB4DECE00910A7D /* MypageSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FAFBAC2CB4DECE00910A7D /* MypageSeparatorView.swift */; };
 		9E38C1F6B1DB0B110CF9BCB7 /* Pods_Hankkijogbo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AC84CE15CCD6BBF6F508B9D /* Pods_Hankkijogbo.framework */; };
@@ -361,6 +362,7 @@
 		86B761202C3DF60800413059 /* ZipHeaderTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipHeaderTableView.swift; sourceTree = "<group>"; };
 		86B761222C3EC87A00413059 /* ZipListCollectionViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipListCollectionViewCellModel.swift; sourceTree = "<group>"; };
 		86B7612F2C3EEDEE00413059 /* HankkiListViewControllerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HankkiListViewControllerType.swift; sourceTree = "<group>"; };
+		86BD76082D0309CE0070EC5D /* CreateZipTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateZipTextField.swift; sourceTree = "<group>"; };
 		86E78D1B2C46B67400BE0DC3 /* EmptyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
 		86FAFBAC2CB4DECE00910A7D /* MypageSeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSeparatorView.swift; sourceTree = "<group>"; };
 		A2079B932C656F7D00817651 /* ImageCompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCompressor.swift; sourceTree = "<group>"; };
@@ -789,6 +791,7 @@
 		83DBEDA92C2565920042BA48 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				86BD76052D0309A80070EC5D /* CreateZipTextField */,
 				A2AF6FAE2CD99AB300F5271D /* ModifyMenuTextField */,
 				A2AF6FF12CEB5EB900F5271D /* HankkiAccessoryView */,
 				8322D03B2C5FB36B00F6D725 /* HankkiCategoryTagLabel */,
@@ -1245,6 +1248,14 @@
 				86B7611E2C3DE05800413059 /* HankkiListTableViewCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		86BD76052D0309A80070EC5D /* CreateZipTextField */ = {
+			isa = PBXGroup;
+			children = (
+				86BD76082D0309CE0070EC5D /* CreateZipTextField.swift */,
+			);
+			path = CreateZipTextField;
 			sourceTree = "<group>";
 		};
 		86E78D1A2C46B42600BE0DC3 /* Recovered References */ = {
@@ -1995,6 +2006,7 @@
 				A240EA4E2C454B78000FF458 /* HankkiReportOptionCollectionView.swift in Sources */,
 				86880C2D2C480AED00CAEF58 /* ZipListViewModel.swift in Sources */,
 				A2FF94132C31660E001ADA03 /* BaseCollectionViewCell.swift in Sources */,
+				86BD76092D0309CE0070EC5D /* CreateZipTextField.swift in Sources */,
 				83DBED922C2564990042BA48 /* HomeViewModel.swift in Sources */,
 				A24A78772CB44BCB0049B031 /* AddMenuViewModel.swift in Sources */,
 				A2C9FCB02C49985800868DF7 /* GetMyZipListResponseDTO.swift in Sources */,

--- a/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextField.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextField.swift
@@ -161,6 +161,7 @@ extension CreateZipTextField {
         textField.inputAccessoryView = accessoryView
     }
 }
+
 private extension CreateZipTextField {
     // textField의 값이 바뀔때, value를 업데이트합니다
     @objc func updateValue(_ textField: UITextField) {

--- a/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextField.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextField.swift
@@ -1,0 +1,150 @@
+//
+//  CreateZipTextField.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 12/6/24.
+//
+
+import UIKit
+
+final class CreateZipTextField: UIView {
+    
+    // MARK: - Properties
+    
+    private let titleText: String
+    private let placeholderText: String
+    private let maxLength: Int
+    private let regex: String
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel()
+    private let textField = UITextField()
+    private let textFieldLine = UIView()
+    
+    // MARK: - Init
+    
+    init(
+        titleText: String,
+        placeholderText: String,
+        maxLength: Int,
+        regex: String
+    ) {
+        self.titleText = titleText
+        self.placeholderText = placeholderText
+        self.maxLength = maxLength
+        self.regex = regex
+        
+        super.init(frame: .zero)
+        
+        setupHierarchy()
+        setupLayout()
+        setupStyle()
+        setupDelegate()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension CreateZipTextField {
+    func setupHierarchy() {
+        self.addSubviews(
+            titleLabel,
+            textField,
+            textFieldLine
+        )
+    }
+    
+    func setupLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(8)
+            $0.top.equalToSuperview()
+        }
+        
+        textField.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.top.equalTo(titleLabel.snp.bottom)
+            $0.height.equalTo(40)
+        }
+        
+        textFieldLine.snp.makeConstraints {
+            $0.horizontalEdges.equalTo(textField)
+            $0.top.equalTo(textField.snp.bottom)
+            $0.height.equalTo(1)
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+    func setupStyle() {
+        titleLabel.do {
+            $0.attributedText = UILabel.setupAttributedText(
+                for: PretendardStyle.body6,
+                withText: titleText,
+                color: .gray500
+            )
+        }
+        
+        textField.do {
+            $0.addPadding(left: 8)
+            
+            $0.font = UIFont.setupPretendardStyle(of: .subtitle2)
+            $0.textColor = .gray800
+            $0.changePlaceholderColor(
+                forPlaceHolder: placeholderText,
+                forColor: .gray300
+            )
+        }
+        
+        textFieldLine.do {
+            $0.backgroundColor = .gray200
+        }
+    }
+    
+    func setupDelegate() {
+        textField.delegate = self
+    }
+}
+
+private extension CreateZipTextField {
+    // regex를 기반으로, 정규식에과 일치하는 입력일 경우 true를 반환합니다.
+    func isValidString(_ s: String, regex: String) -> Bool {
+        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
+        return predicate.evaluate(with: s)
+    }
+}
+
+extension CreateZipTextField: UITextFieldDelegate {
+    
+    // textField의 편집을 시작합니다
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        textFieldLine.backgroundColor = .gray500
+    }
+    
+    // textField의 편집을 종료합니다
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        let currentText = textField.text ?? ""
+        
+        textFieldLine.backgroundColor = .gray200
+        textField.text = String(currentText.prefix(maxLength))
+    }
+    
+    // textField의 text의 내용 수정을 감지합니다.
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let currentText = (textField.text ?? "")
+        let updatedText = currentText+string
+        
+        // 정규식에 맞는 텍스트만 입력되도록 합니다. (+ 스페이스 바, 백스페이스)
+        if !isValidString(string, regex: regex) && string != " " && !string.isEmpty {
+            return false
+        }
+        
+        // TextField의 최대 글자수를 제한 합니다.
+        if updatedText.count > maxLength + 1 {
+            textField.text = String(updatedText.prefix(maxLength))
+            return false
+        }
+        return true
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextFieldType.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextFieldType.swift
@@ -103,24 +103,20 @@ private extension CreateZipTextField {
         }
         
         // 현재 textField에 첫번째 태그가 입력되어있는 경우
+        let firstTag = getFirstTag(textField.text ?? "")
+        
         if currentText.contains(" ") {
             if currentText.hasSuffix("#") {
-                let arr = (textField.text ?? "").split(separator: " ").map { String($0) }
-                textField.text = arr[0]
+                textField.text = firstTag
                 return
             }
             
-            let arr = (textField.text ?? "").split(separator: " ").map { String($0) }
-            let firstTagCount = arr[0].count
-            
-            textField.text = String(currentText.prefix(firstTagCount + 1 + CreateZipLiterals.tagMaxCount))
+            textField.text = String(currentText.prefix(firstTag.count + 1 + CreateZipLiterals.tagMaxCount))
         }
     }
     
     func replaceTagTextField(_ textField: UITextField, string: String, currentText: String) -> Bool {
-        let updatedText: String = currentText+string
-    
-        var firstTagCount = 0
+        let updatedText: String = currentText + string
         
         // 현재 입력된 TextField의 마지막글자를 반환합니다.
         var lastChar = ""
@@ -160,12 +156,7 @@ private extension CreateZipTextField {
             textField.text = String(updatedText.prefix(CreateZipLiterals.tagMaxCount))
             return false
         }
-        
-        if currentText.contains(" ") {
-            let arr = (textField.text ?? "").split(separator: " ").map { String($0) }
-            firstTagCount = arr[0].count
-        }
-        
+
         // 현재 입력 : 스페이스
         
         if string == " " {
@@ -179,18 +170,28 @@ private extension CreateZipTextField {
             // 첫번째 태그를 입력을 마무리하고, 두번째 태그를 작성하려고하는 경우
             // -> 첫번째 태그를 완성하고, 두번째 태그 작성을 위해 #을 자동으로 입력한다.
             else {
-                firstTagCount = currentText.count
                 textField.text = "\(currentText) #"
                 return false
             }
         }
         
+        let firstTag = getFirstTag(textField.text ?? "")
+        
         // 두번째 태그가 최대 글자수를 넘지 않게 막는다.
-        if updatedText.count > firstTagCount + 1 + CreateZipLiterals.tagMaxCount + 1 {
-            textField.text = String(updatedText.prefix(firstTagCount + 1 + CreateZipLiterals.tagMaxCount))
+        if updatedText.count > firstTag.count + 1 + CreateZipLiterals.tagMaxCount + 1 {
+            textField.text = String(updatedText.prefix(firstTag.count + 1 + CreateZipLiterals.tagMaxCount))
             return false
         }
         
         return true
+    }
+}
+
+private extension CreateZipTextField {
+    // 첫번째 입력된 태그를 반환합니다
+    // 띄어쓰기 기준
+    func getFirstTag(_ string: String) -> String {
+        let arr = string.split(separator: " ").map { String($0) }
+        return arr[0]
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextFieldType.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextFieldType.swift
@@ -1,0 +1,155 @@
+//
+//  CreateZipTextFieldType.swift
+//  Hankkijogbo
+//
+//  Created by 심서현 on 12/6/24.
+//
+
+import UIKit
+
+extension CreateZipTextField {
+    enum CreateZipTextFieldType {
+        case tag
+        case title
+        
+        func textFieldDidBeginEditing(for instance: CreateZipTextField) -> (UITextField) -> Void {
+            switch self {
+            case .tag:
+                return { textField in instance.tagTextFieldDidBeginEditing(textField) }
+            default:
+                return { _ in }
+            }
+        }
+        
+        func textFieldDidEndEditing(for instance: CreateZipTextField) -> (UITextField) -> Void {
+            switch self {
+            case .tag:
+                return { textField in instance.tagTextFieldDidBeginEditing(textField) }
+            default:
+                return { _ in }
+            }
+        }
+        
+        func replaceTextField(for instance: CreateZipTextField) -> (UITextField, String, String) -> Bool {
+            switch self {
+            case .tag:
+                return { textField, string, currentText in
+                    instance.replaceTagTextField(textField, string: string, currentText: currentText)
+                }
+            default: return { _, _, _ in true }
+            }
+        }
+    }
+}
+
+private extension CreateZipTextField {
+    
+    func tagTextFieldDidBeginEditing(_ textField: UITextField) {
+        let currentText = textField.text ?? ""
+        if currentText.isEmpty { textField.text = "#" }
+    }
+    
+    func tagTextFieldDidEndEditing(_ textField: UITextField) {
+        let tagMaxCount = 9
+        
+        let currentText = textField.text ?? ""
+        
+        if currentText.count <= 1 {
+            textField.text = ""
+            return
+        }
+        
+        if !currentText.contains(" ") {
+            textField.text = String(currentText.prefix(tagMaxCount))
+        } else {
+            if currentText.hasSuffix("#") {
+                let arr = (textField.text ?? "").split(separator: " ").map { String($0) }
+                textField.text = arr[0]
+                return
+            }
+            
+            let arr = (textField.text ?? "").split(separator: " ").map { String($0) }
+            let firstTagCount = arr[0].count
+            
+            textField.text = String(currentText.prefix(firstTagCount + 1 + tagMaxCount))
+        }
+    }
+    
+    func replaceTagTextField(_ textField: UITextField, string: String, currentText: String) -> Bool {
+        let updatedText: String = currentText+string
+        
+        let tagMaxCount = 9
+        var firstTagCount = 0
+        
+        // 현재 입력된 TextField의 마지막글자를 반환합니다.
+        var lastChar = ""
+        if let text = currentText.last {
+            lastChar = String(text)
+        }
+        
+        // 현재 입력된 TextField의 마지막 글자가 #인 경우
+        if lastChar == "#" {
+            // 텍스트 필드의 상태 : #태그1 #
+            // 첫번째 태그가 입력이 완료 되었고, 두번째 태그를 작성해야하는데 백스페이스를 입력한 경우
+            // 두번째 태그의 입력이 취소 되고, 첫번째 태그를 수정할 수 있게 해야한다.
+            // -> 글자를 지우면 미리 입력된 #과, 태그를 분리하는 띄워쓰기를 동시에 지운다.
+            if string.isEmpty && currentText.count > 1 {
+                textField.text = String(currentText.prefix(currentText.count - 2))
+                return false
+            }
+            // 텍스트 필드의 상태 : #
+            // 첫번째 태그가 입력되지 않은 상태에서, 띄어쓰기로 두번재 태그를 작성하려는 경우
+            // 두번째 태그 작성이 안되게 막아야한다. (첫번째 태그값이 공백이 되면 안됨)
+            // -> 첫번째 태그가 입력되지 않으면 스페이스 키 입력을 막아 2번째 텍스트가 작성되지 않도록한다.
+            else if currentText.count == 1 && string == " " {
+                return false
+            }
+        }
+        
+        // 텍스트 필드의 상태 : #
+        // 현재 입력 : 백스페이스 (지우기)
+        // 첫번째 태그를 작성하지 않고, 백페이스를 입력해 작성되어있던 #도 지우려는 경우
+        // -> 지우기가 되지 않아야한다.
+        if currentText.count == 1 && string.isEmpty {
+            return false
+        }
+        
+        // 첫번째 태그가 최대 글자수를 넘지 않게 막는다.
+        if !currentText.contains(" ") && updatedText.count > tagMaxCount + 1 {
+            textField.text = String(updatedText.prefix(tagMaxCount))
+            return false
+        }
+        
+        if currentText.contains(" ") {
+            let arr = (textField.text ?? "").split(separator: " ").map { String($0) }
+            firstTagCount = arr[0].count
+        }
+        
+        // 현재 입력 : 스페이스
+        
+        if string == " " {
+            // 텍스트 필드의 상태 : #태그1 #태그2작성중
+            // 첫번째 태그를 입력하고, 두번째 태그를 입력하고 있는 중, 한번 더 스페이스를 눌러 3번째 태그를 추가하려는 경우
+            // -> 스페이스가 입력되지 않게 막아야한다.
+            if currentText.contains(" ") {
+                return false
+            }
+            // 텍스트 필드의 상태 : #태그1
+            // 첫번째 태그를 입력을 마무리하고, 두번째 태그를 작성하려고하는 경우
+            // -> 첫번째 태그를 완성하고, 두번째 태그 작성을 위해 #을 자동으로 입력한다.
+            else {
+                firstTagCount = currentText.count
+                textField.text = "\(currentText) #"
+                return false
+            }
+        }
+        
+        // 두번째 태그가 최대 글자수를 넘지 않게 막는다.
+        if updatedText.count > firstTagCount + 1 + tagMaxCount + 1 {
+            textField.text = String(updatedText.prefix(firstTagCount + 1 + tagMaxCount))
+            return false
+        }
+        
+        return true
+    }
+}

--- a/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextFieldType.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/CreateZipTextField/CreateZipTextFieldType.swift
@@ -9,8 +9,44 @@ import UIKit
 
 extension CreateZipTextField {
     enum CreateZipTextFieldType {
-        case tag
         case title
+        case tag
+
+        var titleText: String {
+            switch self {
+            case .title:
+                StringLiterals.CreateZip.TitleInput.label
+            case . tag:
+                StringLiterals.CreateZip.TagInput.label
+            }
+        }
+        
+        var placeholderText: String {
+            switch self {
+            case .title:
+                StringLiterals.CreateZip.TitleInput.placeholder
+            case . tag:
+                StringLiterals.CreateZip.TagInput.placeholder
+            }
+        }
+        
+        var maxLength: Int {
+            switch self {
+            case .title:
+                CreateZipLiterals.titleMaxCount
+            case .tag:
+                CreateZipLiterals.tagMaxCount * 2 + 1
+            }
+        }
+        
+        var regex: String {
+            switch self {
+            case .title:
+                CreateZipLiterals.titleRegex
+            case .tag:
+                CreateZipLiterals.tagRegex
+            }
+        }
         
         func textFieldDidBeginEditing(for instance: CreateZipTextField) -> (UITextField) -> Void {
             switch self {
@@ -24,7 +60,7 @@ extension CreateZipTextField {
         func textFieldDidEndEditing(for instance: CreateZipTextField) -> (UITextField) -> Void {
             switch self {
             case .tag:
-                return { textField in instance.tagTextFieldDidBeginEditing(textField) }
+                return { textField in instance.tagTextFieldDidEndEditing(textField) }
             default:
                 return { _ in }
             }
@@ -50,18 +86,24 @@ private extension CreateZipTextField {
     }
     
     func tagTextFieldDidEndEditing(_ textField: UITextField) {
-        let tagMaxCount = 9
-        
         let currentText = textField.text ?? ""
         
+        // 현재 textField에 아무것도 입력하지 않고, 입력을 종료한 경우
+        // #
+        // textField를 초기화 한다.
         if currentText.count <= 1 {
             textField.text = ""
             return
         }
         
+        // 첫번째 태그를 tagMaxCount를 초과해서 입력하는 경우
         if !currentText.contains(" ") {
-            textField.text = String(currentText.prefix(tagMaxCount))
-        } else {
+            textField.text = String(currentText.prefix(CreateZipLiterals.tagMaxCount))
+            return
+        }
+        
+        // 현재 textField에 첫번째 태그가 입력되어있는 경우
+        if currentText.contains(" ") {
             if currentText.hasSuffix("#") {
                 let arr = (textField.text ?? "").split(separator: " ").map { String($0) }
                 textField.text = arr[0]
@@ -71,14 +113,13 @@ private extension CreateZipTextField {
             let arr = (textField.text ?? "").split(separator: " ").map { String($0) }
             let firstTagCount = arr[0].count
             
-            textField.text = String(currentText.prefix(firstTagCount + 1 + tagMaxCount))
+            textField.text = String(currentText.prefix(firstTagCount + 1 + CreateZipLiterals.tagMaxCount))
         }
     }
     
     func replaceTagTextField(_ textField: UITextField, string: String, currentText: String) -> Bool {
         let updatedText: String = currentText+string
-        
-        let tagMaxCount = 9
+    
         var firstTagCount = 0
         
         // 현재 입력된 TextField의 마지막글자를 반환합니다.
@@ -115,8 +156,8 @@ private extension CreateZipTextField {
         }
         
         // 첫번째 태그가 최대 글자수를 넘지 않게 막는다.
-        if !currentText.contains(" ") && updatedText.count > tagMaxCount + 1 {
-            textField.text = String(updatedText.prefix(tagMaxCount))
+        if !currentText.contains(" ") && updatedText.count > CreateZipLiterals.tagMaxCount + 1 {
+            textField.text = String(updatedText.prefix(CreateZipLiterals.tagMaxCount))
             return false
         }
         
@@ -145,8 +186,8 @@ private extension CreateZipTextField {
         }
         
         // 두번째 태그가 최대 글자수를 넘지 않게 막는다.
-        if updatedText.count > firstTagCount + 1 + tagMaxCount + 1 {
-            textField.text = String(updatedText.prefix(firstTagCount + 1 + tagMaxCount))
+        if updatedText.count > firstTagCount + 1 + CreateZipLiterals.tagMaxCount + 1 {
+            textField.text = String(updatedText.prefix(firstTagCount + 1 + CreateZipLiterals.tagMaxCount))
             return false
         }
         

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -37,6 +37,11 @@ final class CreateZipViewController: BaseViewController {
     private let tagInputTextField = TagTextField()
     private let tagInputLineView = UIView()
     
+    private let testTextField = CreateZipTextField(titleText: "테스트",
+                                                   placeholderText: "테스트입니다...",
+                                                   maxLength: 5,
+                                                   regex:"^[ㄱ-힣a-zA-Z0-9{}\\[\\]/?.,;:|)*~`!^\\-_+<>@#\\$%&\\\\=\\('\"\"\\\\]*$")
+    
     private lazy var submitButton = MainButton(titleText: StringLiterals.CreateZip.submitButton, isValid: false, buttonHandler: submitButtonDidTap)
     private let hankkiAccessoryView = HankkiAccessoryView(text: StringLiterals.CreateZip.submitButton)
 
@@ -142,7 +147,8 @@ final class CreateZipViewController: BaseViewController {
             tagInputTitle,
             tagInputTextField,
             tagInputLineView,
-            submitButton
+            submitButton,
+            testTextField
         )
         titleCountView.addSubview(titleCountLabel)
     }
@@ -206,6 +212,12 @@ final class CreateZipViewController: BaseViewController {
             $0.centerX.equalToSuperview()
             $0.height.equalTo(54)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
+        }
+        
+        testTextField.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(22)
+            $0.top.equalTo(tagInputTextField.snp.bottom)
+            
         }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -26,25 +26,33 @@ final class CreateZipViewController: BaseViewController {
     private let viewTitleLabel = UILabel()
     private let descriptionLabel = UILabel()
     
-    private let titleInputTitle = UILabel()
-    private let titleInputTextField = UITextField()
-    private let titleInputLineView = UIView()
-    
     private let titleCountView = UIView()
     private let titleCountLabel = UILabel()
     
-    private let tagInputTitle = UILabel()
-    private let tagInputTextField = TagTextField()
-    private let tagInputLineView = UIView()
+    private let titleTextField = CreateZipTextField(
+        type: .title,
+        titleText: StringLiterals.CreateZip.TitleInput.label,
+        placeholderText: StringLiterals.CreateZip.TitleInput.placeholder,
+        maxLength: 18,
+        regex: "^[ㄱ-힣a-zA-Z0-9{}\\[\\]/?.,;:|)*~`!^\\-_+<>@#\\$%&\\\\=\\('\"\"\\\\]*$"
+    )
     
-    private let testTextField = CreateZipTextField(titleText: "테스트",
-                                                   placeholderText: "테스트입니다...",
-                                                   maxLength: 5,
-                                                   regex:"^[ㄱ-힣a-zA-Z0-9{}\\[\\]/?.,;:|)*~`!^\\-_+<>@#\\$%&\\\\=\\('\"\"\\\\]*$")
+    private let tagTextField = CreateZipTextField(
+        type: .tag,
+        titleText: StringLiterals.CreateZip.TagInput.label,
+        placeholderText: StringLiterals.CreateZip.TagInput.placeholder,
+        maxLength: 9 * 2 + 1,
+        regex: "^[ㄱ-힣a-zA-Z0-9]+$"
+    )
     
-    private lazy var submitButton = MainButton(titleText: StringLiterals.CreateZip.submitButton, isValid: false, buttonHandler: submitButtonDidTap)
+    private lazy var submitButton = MainButton(
+        titleText: StringLiterals.CreateZip.submitButton,
+        isValid: false,
+        buttonHandler: submitButtonDidTap
+    )
+    
     private let hankkiAccessoryView = HankkiAccessoryView(text: StringLiterals.CreateZip.submitButton)
-
+    
     // MARK: - Life Cycle
     
     init(isBottomSheetOpen: Bool, storeId: Int? = nil) {
@@ -74,83 +82,31 @@ final class CreateZipViewController: BaseViewController {
     
     override func setupStyle() {
         viewTitleLabel.do {
-            $0.attributedText = UILabel.setupAttributedText(for: SuiteStyle.h1,
-                                                            withText: StringLiterals.CreateZip.viewTitle,
-                                                            color: .gray900)
+            $0.attributedText = UILabel.setupAttributedText(
+                for: SuiteStyle.h1,
+                withText: StringLiterals.CreateZip.viewTitle,
+                color: .gray900
+            )
         }
         
         descriptionLabel.do {
             $0.numberOfLines = 2
-            $0.attributedText = UILabel.setupAttributedText(for: PretendardStyle.body6,
-                                                            withText: StringLiterals.CreateZip.viewDescription,
-                                                            color: .gray400)
+            $0.attributedText = UILabel.setupAttributedText(
+                for: PretendardStyle.body6,
+                withText: StringLiterals.CreateZip.viewDescription,
+                color: .gray400
+            )
         }
-        
-        titleInputTitle.do {
-            $0.attributedText = UILabel.setupAttributedText(for: PretendardStyle.body6,
-                                                            withText: StringLiterals.CreateZip.TitleInput.label,
-                                                            color: .gray500)
-        }
-        
-        titleInputTextField.do {
-            $0.tag = 0
-            $0.addPadding(left: 8, right: 14)
-            $0.font = UIFont.setupPretendardStyle(of: .subtitle2)
-            $0.textColor = .gray800
-            
-            $0.changePlaceholderColor(forPlaceHolder: StringLiterals.CreateZip.TitleInput.placeholder,
-                                      forColor: .gray300)
-            
-            $0.rightViewMode = .always
-            $0.rightView = titleCountView
-        }
-        
-        titleInputLineView.do {
-            $0.backgroundColor = .gray200
-        }
-            
-        titleCountLabel.do {
-            $0.attributedText = UILabel.setupAttributedText(for: PretendardStyle.body8,
-                                                            withText: "(0/\(titleMaxCount))",
-                                                            color: .gray300)
-        }
-        
-        tagInputTitle.do {
-            $0.attributedText = UILabel.setupAttributedText(for: PretendardStyle.body6,
-                                                            withText: StringLiterals.CreateZip.TagInput.label,
-                                                            color: .gray500)
-        }
-        
-        tagInputTextField.do {
-            $0.tag = 1
-            $0.addPadding(left: 8)
-            $0.font = UIFont.setupPretendardStyle(of: .subtitle2)
-            $0.textColor = .gray800
-            
-            $0.changePlaceholderColor(forPlaceHolder: StringLiterals.CreateZip.TagInput.placeholder,
-                                      forColor: .gray300)
-        }
-        
-        tagInputLineView.do {
-            $0.backgroundColor = .gray200
-        }
-
     }
     
     override func setupHierarchy() {
         view.addSubviews(
             viewTitleLabel,
             descriptionLabel,
-            titleInputTitle,
-            titleInputTextField,
-            titleInputLineView,
-            tagInputTitle,
-            tagInputTextField,
-            tagInputLineView,
-            submitButton,
-            testTextField
+            titleTextField,
+            tagTextField,
+            submitButton
         )
-        titleCountView.addSubview(titleCountLabel)
     }
     
     override func setupLayout() {
@@ -164,60 +120,21 @@ final class CreateZipViewController: BaseViewController {
             $0.horizontalEdges.equalToSuperview().offset(22)
         }
         
-        titleInputTitle.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(30)
+        titleTextField.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(22)
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(36)
         }
         
-        titleInputTextField.snp.makeConstraints {
+        tagTextField.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(22)
-            $0.top.equalTo(titleInputTitle.snp.bottom)
-            $0.height.equalTo(40)
+            $0.top.equalTo(titleTextField.snp.bottom).offset(20)
         }
         
-        titleInputLineView.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview().inset(22)
-            $0.height.equalTo(1)
-            $0.top.equalTo(titleInputTextField.snp.bottom)
-        }
-        
-        tagInputTitle.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(30)
-            $0.top.equalTo(titleInputLineView.snp.bottom).offset(20)
-        }
-        
-        tagInputTextField.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview().inset(22)
-            $0.top.equalTo(tagInputTitle.snp.bottom)
-            $0.height.equalTo(40)
-        }
-        
-        tagInputLineView.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview().inset(22)
-            $0.height.equalTo(1)
-            $0.top.equalTo(tagInputTextField.snp.bottom)
-        }
-        
-        titleCountView.snp.makeConstraints {
-            $0.width.equalTo(40)
-            $0.height.equalTo(50)
-        }
-        
-        titleCountLabel.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(14)
-            $0.centerY.equalToSuperview()
-        }
         submitButton.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(22)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(54)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
-        }
-        
-        testTextField.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview().inset(22)
-            $0.top.equalTo(tagInputTextField.snp.bottom)
-            
         }
     }
 }
@@ -241,19 +158,19 @@ private extension CreateZipViewController {
             $0.edges.equalToSuperview()
         }
         
-        titleInputTextField.inputAccessoryView = accessoryView
-        tagInputTextField.inputAccessoryView = accessoryView
+        //        titleInputTextField.inputAccessoryView = accessoryView
+        //        tagInputTextField.inputAccessoryView = accessoryView
     }
     
     func setupDelegate() {
-        titleInputTextField.delegate = self
-        tagInputTextField.delegate = self
+        //        titleInputTextField.delegate = self
+        //        tagInputTextField.delegate = self
     }
     
     func setupAddTarget() {
-        titleInputTextField.addTarget(self, action: #selector(titleTextFieldDidChange), for: .editingChanged)
-        titleInputTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
-        tagInputTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        //        titleInputTextField.addTarget(self, action: #selector(titleTextFieldDidChange), for: .editingChanged)
+        //        titleInputTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        //        tagInputTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         hankkiAccessoryView.button.addTarget(self, action: #selector(submitButtonDidTap), for: .touchUpInside)
     }
     
@@ -267,14 +184,14 @@ private extension CreateZipViewController {
     }
     
     @objc func submitButtonDidTap() {
-        let arr = (tagInputTextField.text ?? "").split(separator: " ").map { String($0) }
-        let data = PostZipRequestDTO(title: titleInputTextField.text ?? " ", details: arr)
+        //        let arr = (tagInputTextField.text ?? "").split(separator: " ").map { String($0) }
+        //        let data = PostZipRequestDTO(title: titleInputTextField.text ?? " ", details: arr)
         
-        viewModel.postZip(data, onConflict: resetTitleTextField, completion: dismissSelf)
+        //        viewModel.postZip(data, onConflict: resetTitleTextField, completion: dismissSelf)
     }
     
     func resetTitleTextField() {
-        self.titleInputTextField.text = ""
+        titleTextField.value = ""
         submitButton.setupIsValid(false)
         hankkiAccessoryView.updateStyle(isValid: false)
     }
@@ -293,170 +210,9 @@ private extension CreateZipViewController {
     }
     
     func isFormValid() {
-        let isValid = !(titleInputTextField.text ?? "").isEmpty && (tagInputTextField.text ?? "").count > 1
+        //        let isValid = !(titleInputTextField.text ?? "").isEmpty && (tagInputTextField.text ?? "").count > 1
+        let isValid = true
         submitButton.setupIsValid(isValid)
         hankkiAccessoryView.updateStyle(isValid: isValid)
-    }
-}
-
-// MARK: - delegate
-
-extension CreateZipViewController: UITextFieldDelegate {
-    
-    func textFieldDidBeginEditing(_ textField: UITextField) {
-        setupInputAccessoryView()
-        
-        switch textField.tag {
-        case 0:
-            titleInputLineView.backgroundColor = .gray500
-            titleCountLabel.textColor = .gray500
-        case 1:
-            tagInputLineView.backgroundColor = .gray500
-            let currentText = textField.text ?? ""
-            if currentText.isEmpty {
-                textField.text = "#"
-            }
-        default:
-            return
-        }
-    }
-    
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        if textField.tag == 0 {
-            titleInputLineView.backgroundColor = .gray200
-        } else if textField.tag == 1 {
-            tagInputLineView.backgroundColor = .gray200
-        }
-        
-        let currentText = textField.text ?? ""
-        
-        if textField.tag == 0 {
-            titleCountLabel.textColor = .gray300
-            titleInputTextField.text = String(currentText.prefix(titleMaxCount))
-            return
-        }
-        
-        if currentText.count <= 1 {
-            textField.text = ""
-            return
-        }
-        
-        if !currentText.contains(" ") {
-            tagInputTextField.text = String(currentText.prefix(tagMaxCount))
-        } else {
-            if currentText.hasSuffix("#") {
-                let arr = (tagInputTextField.text ?? "").split(separator: " ").map { String($0) }
-                tagInputTextField.text = arr[0]
-                return
-            }
-            
-            tagInputTextField.text = String(currentText.prefix(firstTagCount + 1 + tagMaxCount))
-        }
-    }
-    
-    func isValidString(_ s: String, regex: String) -> Bool {
-        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
-        return predicate.evaluate(with: s)
-    }
-    
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        
-        let currentText = (textField.text ?? "")
-        let updatedText = currentText+string
-        
-        let titleRegex = "^[ㄱ-힣a-zA-Z0-9{}\\[\\]/?.,;:|)*~`!^\\-_+<>@#\\$%&\\\\=\\('\"\"\\\\]*$"
-        let tagRegex = "^[ㄱ-힣a-zA-Z0-9]+$"
-        
-        // 정규식에 맞는 텍스트만 입력되도록 합니다. (+ 스페이스 바, 백스페이스)
-        if !isValidString(string, regex: textField.tag == 0 ? titleRegex : tagRegex) && string != " " && !string.isEmpty {
-            return false
-        }
-        
-        // textField.tag == 0 : 족보 제목
-        // TextField의 글자 수를 제한 합니다.
-        if textField.tag == 0 {
-            if updatedText.count > titleMaxCount + 1 {
-                titleInputTextField.text = String(updatedText.prefix(titleMaxCount))
-                return false
-            }
-            return true
-        }
-        
-        // textField.tag == 1 : 족보 태그
-        
-        // 현재 입력된 TextField의 마지막글자를 반환합니다.
-        var lastChar = ""
-        if let text = currentText.last {
-            lastChar = String(text)
-        }
-        
-        // 현재 입력된 TextField의 마지막 글자가 #인 경우
-        if lastChar == "#" {
-            // 텍스트 필드의 상태 : #태그1 #
-            // 첫번째 태그가 입력이 완료 되었고, 두번째 태그를 작성해야하는데 백스페이스를 입력한 경우
-            // 두번째 태그의 입력이 취소 되고, 첫번째 태그를 수정할 수 있게 해야한다.
-            // -> 글자를 지우면 미리 입력된 #과, 태그를 분리하는 띄워쓰기를 동시에 지운다.
-            if string.isEmpty && currentText.count > 1 {
-                tagInputTextField.text = String(currentText.prefix(currentText.count - 2))
-                return false
-            }
-            // 텍스트 필드의 상태 : #
-            // 첫번째 태그가 입력되지 않은 상태에서, 띄어쓰기로 두번재 태그를 작성하려는 경우
-            // 두번째 태그 작성이 안되게 막아야한다. (첫번째 태그값이 공백이 되면 안됨)
-            // -> 첫번째 태그가 입력되지 않으면 스페이스 키 입력을 막아 2번째 텍스트가 작성되지 않도록한다.
-            else if currentText.count == 1 && string == " " {
-                return false
-            }
-        }
-        
-        // 텍스트 필드의 상태 : #
-        // 현재 입력 : 백스페이스 (지우기)
-        // 첫번째 태그를 작성하지 않고, 백페이스를 입력해 작성되어있던 #도 지우려는 경우
-        // -> 지우기가 되지 않아야한다.
-        if currentText.count == 1 && string.isEmpty {
-            return false
-        }
-        
-        // 첫번째 태그가 최대 글자수를 넘지 않게 막는다.
-        if !currentText.contains(" ") && updatedText.count > tagMaxCount + 1 {
-            tagInputTextField.text = String(updatedText.prefix(tagMaxCount))
-            return false
-        }
-        
-        // 현재 입력 : 스페이스
-        if string == " " {
-            // 텍스트 필드의 상태 : #태그1 #태그2작성중
-            // 첫번째 태그를 입력하고, 두번째 태그를 입력하고 있는 중, 한번 더 스페이스를 눌러 3번째 태그를 추가하려는 경우
-            // -> 스페이스가 입력되지 않게 막아야한다.
-            if currentText.contains(" ") {
-                return false
-            }
-            // 텍스트 필드의 상태 : #태그1
-            // 첫번째 태그를 입력을 마무리하고, 두번째 태그를 작성하려고하는 경우
-            // -> 첫번째 태그를 완성하고, 두번째 태그 작성을 위해 #을 자동으로 입력한다.
-            else {
-                firstTagCount = currentText.count
-                tagInputTextField.text = "\(currentText) #"
-                return false
-            }
-        }
-        
-        // 두번째 태그가 최대 글자수를 넘지 않게 막는다.
-        if updatedText.count > firstTagCount + 1 + tagMaxCount + 1 {
-            tagInputTextField.text = String(updatedText.prefix(firstTagCount + 1 + tagMaxCount))
-            return false
-        }
-        
-        return true
-    }
-    
-    func moveCursorToEnd(_ textField: UITextField) {
-        if let endPosition = textField.position(from: textField.endOfDocument, offset: 0) {
-            textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition)
-        }
-    }
-    
-    func textFieldDidChangeSelection(_ textField: UITextField) {
-        if textField.tag == 1 { moveCursorToEnd(textField) }
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -169,8 +169,8 @@ private extension CreateZipViewController {
 private extension CreateZipViewController {
     
     @objc func submitButtonDidTap() {
-        let title = titleTextField.value
-        let tagList = tagTextField.value.split(separator: " ").map { String($0) }
+        let title: String = titleTextField.value
+        let tagList: [String] = tagTextField.value.split(separator: " ").map { String($0) }
         
         let data = PostZipRequestDTO(title: title, details: tagList)
         

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -26,8 +26,6 @@ final class CreateZipViewController: BaseViewController {
     
     private var firstTagCount: Int = 0
     
-    private var isValid: Bool = false
-    
     // MARK: - UI Properties
     
     private let viewTitleLabel: UILabel = UILabel()


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
#### 기존 CreateZipViewController의 코드를 리펙토링했습니다.
- TextField를 컴포넌트화 하여 VC에 필요 없는 로직을 제거했습니다.
- TextField의 text 최대 길이와 regex를 상수로 빼서 사용하여 유지보수에 용이하도록 변경했습니다 


## 🚨 참고 사항
- **replaceTagTextField**
`replaceTagTextField` 함수의 경우, tag 입력을 제한하는 함수입니다!
tag가 [#태그내용1 #태그내용] 으로 입력 - 이때 태그는 `#`기호를 포함해 **9자**- 될 수 있도록 제약을 걸어두었습니다.

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [ ] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #288
