### PR TITLE
[Feat] #341 - 3차 스프린트 Amplitude 적용

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarItem.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Components/TabBar/TabBarItem.swift
@@ -53,7 +53,7 @@ enum TabBarItem: CaseIterable {
         }
     }
     
-    var amplitudeButtonName: String{
+    var amplitudeButtonName: String {
         switch self {
         case .home: return AmplitudeLiterals.Tabbar.tabHome
         case .report: return AmplitudeLiterals.Tabbar.tabReport

--- a/Hankkijogbo/Hankkijogbo/Global/Consts/AmplitudeLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/AmplitudeLiterals.swift
@@ -22,8 +22,16 @@ enum AmplitudeLiterals {
     
     enum Mypage {
         static let tabMyzip = "Mypage_MyZip_Click"
+        static let tabShare = "Mypage_MyJokbo_Share"
+        static let completedShare = "Mypage_MyJokbo_Share_Completed"
     }
 
+    enum SharedZip {
+        static let present = "Shared_Jokbo_Page"
+        static let tabAdd = "Shared_Jokbo_MyJokbo_Add"
+        static let completedAdd = "Shared_Jokbo_MyJokbo_Add_Completed"
+    }
+    
     enum ZipList {
         static let tabCreateZip = "Mypage_MyJokbo_NewJokbo_Create"
     }
@@ -39,5 +47,6 @@ enum AmplitudeLiterals {
     
     enum Property {
         static let university = "university"
+        static let zip = "족보"
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Consts/AmplitudeLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/AmplitudeLiterals.swift
@@ -6,6 +6,15 @@
 //
 
 enum AmplitudeLiterals {
+    enum Home {
+        static let tabHankki = "Home_StoreCard_Click"
+        static let tabPin = "Home_Map_Pin_Click"
+        
+        static let tabFilter = "Home_Detail_Filter_Completed"
+        
+        static let tabCategory = "Home_Food_Categories_Click"
+        
+    }
     enum Tabbar {
         static let tabHome = "Nav_Home_Click"
         static let tabReport = "Nav_Report_Click"
@@ -48,5 +57,9 @@ enum AmplitudeLiterals {
     enum Property {
         static let university = "university"
         static let zip = "족보"
+        static let store = "식당"
+        static let food = "food"
+        static let filterSort = "정렬"
+        static let filterPrice = "가격대"
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Global/Consts/AmplitudeLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/AmplitudeLiterals.swift
@@ -30,7 +30,7 @@ enum AmplitudeLiterals {
     }
     
     enum Mypage {
-        static let tabMyzip = "Mypage_MyZip_Click"
+        static let tabMyzip = "Mypage_MyJokbo_Click"
         static let tabShare = "Mypage_MyJokbo_Share"
         static let completedShare = "Mypage_MyJokbo_Share_Completed"
     }

--- a/Hankkijogbo/Hankkijogbo/Global/Consts/AmplitudeLiterals.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Consts/AmplitudeLiterals.swift
@@ -36,4 +36,8 @@ enum AmplitudeLiterals {
     enum UnivSelect {
         static let tabSubmit = "UniversityChoice_AnyUniv_Click"
     }
+    
+    enum Property {
+        static let university = "university"
+    }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/CreateZip/View/CreateZipViewController.swift
@@ -50,7 +50,7 @@ final class CreateZipViewController: BaseViewController {
     
     // MARK: - Life Cycle
     
-    init(isBottomSheetOpen: Bool, storeId: Int? = nil, zipId: Int? = nil, type: CreateZipViewControllerType = .myZip) {
+    init(isBottomSheetOpen: Bool, storeId: Int? = nil, zipId: Int? = nil, type: CreateZipViewControllerType = .myZip, prevTitle: String? = nil) {
         self.isBottomSheetOpen = isBottomSheetOpen
         self.storeId = storeId
         self.zipId = zipId
@@ -220,6 +220,9 @@ private extension CreateZipViewController {
     }
     
     func presentMyZipListViewController() {
+        SetupAmplitude.shared.logEvent(AmplitudeLiterals.SharedZip.completedAdd,
+                                       eventProperties: [AmplitudeLiterals.Property.zip: titleTextField.value])
+        
         DispatchQueue.main.async {
             // 족보 만들기를 완료해서, 서버에서 생성이되면 나의 족보 리스트 페이지로 이동한다.
             if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/Cell/ZipHeaderTableView.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/Cell/ZipHeaderTableView.swift
@@ -23,6 +23,8 @@ final class ZipHeaderTableView: UITableViewHeaderFooterView {
     var showAlert: ((String) -> Void)?
     var shareZip: (() -> Void)?
     
+    private var zipName: String = ""
+    
     // MARK: - UI Properties
     
     private let headerView = UIView()
@@ -164,6 +166,8 @@ private extension ZipHeaderTableView {
     
     @objc func shareButtonDidTap() {
         guard let shareZip = shareZip else { return }
+        SetupAmplitude.shared.logEvent(AmplitudeLiterals.Mypage.tabShare,
+                                       eventProperties: [AmplitudeLiterals.Property.zip: zipName])
         shareZip()
     }
 }
@@ -207,9 +211,10 @@ private extension ZipHeaderTableView {
 }
 
 extension ZipHeaderTableView {
-    func dataBind(_ data: Model?, isShareButtonHidden: Bool, shareZip: @escaping ()-> Void) {
+    func dataBind(_ data: Model?, isShareButtonHidden: Bool, shareZip: @escaping () -> Void) {
         self.shareZip = shareZip
         headerLabel.text = data?.title
+        zipName = data?.title ?? ""
         setupTagStackView(data?.details ?? [])
         nameLabel.text = data?.name
         shareButton.isHidden = isShareButtonHidden

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/ZipDetailViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/View/ZipDetailViewController.swift
@@ -110,6 +110,12 @@ private extension ZipDetailViewController {
                                 isShareButtonHidden: type == .sharedZip,
                                 shareZip: shareZip)
             
+            if type == .sharedZip {
+                let zipName = viewModel.zipInfo?.title ?? ""
+                SetupAmplitude.shared.logEvent(AmplitudeLiterals.SharedZip.present,
+                                               eventProperties: [AmplitudeLiterals.Property.zip: zipName])
+            }
+            
             isHeaderSetting = true
         }
     }
@@ -169,9 +175,15 @@ private extension ZipDetailViewController {
     
     // 공유 받은 족보 -> 족보 저장 뷰
     func presentAddZipViewController() {
+        let zipName = viewModel.zipInfo?.title ?? ""
+        SetupAmplitude.shared.logEvent(AmplitudeLiterals.SharedZip.tabAdd,
+                                       eventProperties: [AmplitudeLiterals.Property.zip: zipName])
+        
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let rootViewController = windowScene.windows.first?.rootViewController as? UINavigationController {
-            let addZipViewController = CreateZipViewController(isBottomSheetOpen: false, zipId: zipId, type: .sharedZip)
+            let addZipViewController = CreateZipViewController(isBottomSheetOpen: false,
+                                                               zipId: zipId,
+                                                               type: .sharedZip)
             rootViewController.pushViewController(addZipViewController, animated: true)
         }
     }

--- a/Hankkijogbo/Hankkijogbo/Present/HankkiList/ViewModel/HankkiListViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/HankkiList/ViewModel/HankkiListViewModel.swift
@@ -137,6 +137,9 @@ extension HankkiListViewModel {
         let templeteID: Int64 = Int64(StringLiterals.Kakao.zipShareTemplete)
         
         let imageURL: String = hankkiList[0].imageURL.isEmpty ? StringLiterals.SharedZip.zipShareDefaultImageURL : hankkiList[0].imageURL
+        
+        let name: String = zipInfo?.title ?? ""
+        let sender: String = zipInfo?.name ?? ""
  
         let templetArgs: [String: String] = ["IMAGE_URL": imageURL,
                                              "FAVORITE_ID": String(zipInfo?.id ?? 0),
@@ -150,6 +153,8 @@ extension HankkiListViewModel {
                     print("error : \(error)")
                 } else {
                     print("sharing is success")
+                    SetupAmplitude.shared.logEvent(AmplitudeLiterals.Mypage.completedShare,
+                                                   eventProperties: [AmplitudeLiterals.Property.zip: name])
                     guard let sharingResult else { return }
                     UIApplication.shared.open(sharingResult.url, options: [:], completionHandler: nil)
                 }

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/Extension/CoreLocation.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/Extension/CoreLocation.swift
@@ -202,6 +202,9 @@ extension HomeViewController {
             marker.touchHandler = { [weak self] _ in
                 self?.rootView.bottomSheetView.viewLayoutIfNeededWithHiddenAnimation()
                 self?.showMarkerInfoCard(at: index, pinId: location.id)
+                
+                SetupAmplitude.shared.logEvent(AmplitudeLiterals.Home.tabPin,
+                                               eventProperties: [AmplitudeLiterals.Property.store: location.name])
                 return true
             }
             markers.append(marker)

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/FilteringBottomSheetViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/FilteringBottomSheetViewController.swift
@@ -234,12 +234,14 @@ private extension FilteringBottomSheetViewController {
             viewModel.priceCategory = selectedPriceData.tag
         } else { viewModel.priceCategory = nil }
 
-
         if let selectedSortValue = selectedSortValue,
            let selectedSortData = sortData.first(where: { $0.name == selectedSortValue }) {
             viewModel.sortOption = selectedSortData.tag
         } else { viewModel.sortOption = nil }
-
+        
+        SetupAmplitude.shared.logEvent(AmplitudeLiterals.Home.tabFilter,
+                                       eventProperties: [AmplitudeLiterals.Property.filterSort: selectedSortValue ?? "",
+                                                         AmplitudeLiterals.Property.filterPrice: selectedPriceValue ?? ""])
         viewModel.updateHankkiList()
         dimmedViewDidTap()
     }

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/HomeViewController.swift
@@ -272,6 +272,8 @@ extension HomeViewController: UICollectionViewDelegate {
             changeButtonTitle(for: rootView.typeButton, newTitle: "전체")
         } else if indexPath.item - 1 < viewModel.categoryFilters.count {
             let selectedCategory = viewModel.categoryFilters[indexPath.item - 1]
+            SetupAmplitude.shared.logEvent(AmplitudeLiterals.Home.tabCategory,
+                                           eventProperties: [AmplitudeLiterals.Property.food: selectedCategory.name])
             viewModel.selectedStoreCategoryIndex = indexPath.item
             viewModel.storeCategory = selectedCategory.tag
             changeButtonTitle(for: rootView.typeButton, newTitle: selectedCategory.name)

--- a/Hankkijogbo/Hankkijogbo/Present/Home/View/TotalListBottomSheetView.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Home/View/TotalListBottomSheetView.swift
@@ -308,6 +308,9 @@ extension TotalListBottomSheetView: UICollectionViewDataSource {
 extension TotalListBottomSheetView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let pinId = data[indexPath.item].id
+        SetupAmplitude.shared.logEvent(AmplitudeLiterals.Home.tabHankki,
+                                       eventProperties: [AmplitudeLiterals.Property.store: data[indexPath.item].name])
+        
         delegate?.didSelectHankkiCell(at: indexPath.item, pinId: pinId)
     }
 }

--- a/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageCollectionViewCellEnum.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/Mypage/View/MypageCollectionViewCellEnum.swift
@@ -33,6 +33,7 @@ extension MypageViewController {
         case .hankki:
             switch itemIndex {
             case 0:
+                SetupAmplitude.shared.logEvent(AmplitudeLiterals.Mypage.tabMyzip)
                 navigateToZipListViewController()
             case 1:
                 navigateToHankkiListViewController(.reported)

--- a/Hankkijogbo/Hankkijogbo/Present/UnivSelect/ViewModel/UnivSelectViewModel.swift
+++ b/Hankkijogbo/Hankkijogbo/Present/UnivSelect/ViewModel/UnivSelectViewModel.swift
@@ -53,7 +53,7 @@ extension UnivSelectViewModel {
         NetworkService.shared.userService.postMeUniversity(requestBody: request) { result in
             result.handleNetworkResult(delegate: self.delegate) { _ in
                 SetupAmplitude.shared.logEvent(AmplitudeLiterals.UnivSelect.tabSubmit,
-                                               eventProperties: ["university_name": currentUniversity.name])
+                                               eventProperties: [AmplitudeLiterals.Property.university: currentUniversity.name])
                 // local에 대학 정보 저장
                 UserDefaults.standard.saveUniversity(currentUniversity)
                 NotificationCenter.default.post(name: NSNotification.Name(StringLiterals.NotificationName.locationDidUpdate), object: nil, userInfo: ["university": currentUniversity])


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 엠플리튜드를 적용했습니다.


## 🖥️ 주요 코드 설명
`Amplitude Literals`
- 쏼라쏼라
```swift
    enum Property {
        static let university = "university"
        static let zip = "족보"
        static let store = "식당"
        static let food = "food"
        static let filterSort = "정렬"
        static let filterPrice = "가격대"
    }
```

```swift
            SetupAmplitude.shared.logEvent(AmplitudeLiterals.Home.tabCategory,
                                           eventProperties: [AmplitudeLiterals.Property.food: selectedCategory.name])
```
property는 다른 화면에서도 공통적으로 사용되는 경우가 있어서... (food)의 경우, property만 관리할 수 있게 화면별로 정의하지 않고 따로 빼두었습니다! 
아래처럼 사용해요


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #341
