### PR TITLE
[Fix] #350 - access token 만료시 재발급이 안되는 문제 해결

### DIFF
--- a/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
+++ b/Hankkijogbo/Hankkijogbo/Application/SceneDelegate.swift
@@ -76,7 +76,7 @@ private extension SceneDelegate {
     
     /// 서버에 사용자의 정보가 저장되어있는지 확인합니다.
     func checkServerAccountStatus() {
-        let accessToken: String = UserDefaults.standard.getAccesshToken()
+        let accessToken: String = UserDefaults.standard.getAccessToken()
         
         if !accessToken.isEmpty {
             getMe()

--- a/Hankkijogbo/Hankkijogbo/Global/Extensions/UserDefaults+.swift
+++ b/Hankkijogbo/Hankkijogbo/Global/Extensions/UserDefaults+.swift
@@ -11,7 +11,7 @@ extension UserDefaults {
     /// 유저의 로그인 유무를 확인합니다.
     /// UserDefaults에 AccessToken이 저장되어있을 경우 로그인이 되어있다고 판단합니다.
     var isLogin: Bool {
-        return !UserDefaults.standard.getAccesshToken().isEmpty
+        return !UserDefaults.standard.getAccessToken().isEmpty
     }
     
     func saveUserId(_ userId: String) {
@@ -41,7 +41,7 @@ extension UserDefaults {
         return UserDefaults.standard.string(forKey: UserDefaultsKey.refreshToken.rawValue) ?? ""
     }
     
-    func getAccesshToken() -> String {
+    func getAccessToken() -> String {
         return UserDefaults.standard.string(forKey: UserDefaultsKey.accessToken.rawValue) ?? ""
     }
     

--- a/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
@@ -69,6 +69,13 @@ extension BaseTargetType {
     var headers: [String: String]? {
         var header: [String: String] = [:]
         
+        if UserDefaults.standard.isLogin {
+            // 유저가 로그인 한 회원일 경우
+            // Access Token을 header-Authorization 에 삽입해 전송한다.
+            let accessToken = UserDefaults.standard.getAccesshToken()
+            header["Authorization"] = URLConstant.bearer + "\(accessToken)"
+        }
+        
         switch headerType {
             
         case .loginHeader(let accessToken):
@@ -94,13 +101,6 @@ extension BaseTargetType {
             
         default:
             header["Content-Type"] = "application/json"
-        }
-        
-        if UserDefaults.standard.isLogin {
-            // 유저가 로그인 한 회원일 경우
-            // Access Token을 header-Authorization 에 삽입해 전송한다.
-            let accessToken = UserDefaults.standard.getAccesshToken()
-            header["Authorization"] = URLConstant.bearer + "\(accessToken)"
         }
         
         return header

--- a/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
+++ b/Hankkijogbo/Hankkijogbo/Network/Base/BaseTargetType.swift
@@ -72,7 +72,7 @@ extension BaseTargetType {
         if UserDefaults.standard.isLogin {
             // 유저가 로그인 한 회원일 경우
             // Access Token을 header-Authorization 에 삽입해 전송한다.
-            let accessToken = UserDefaults.standard.getAccesshToken()
+            let accessToken = UserDefaults.standard.getAccessToken()
             header["Authorization"] = URLConstant.bearer + "\(accessToken)"
         }
         


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
-  access token 만료시 재발급이 안되는 문제 해결

## 🖥️ 주요 코드 설명
guest 모드 (둘러보기) 구현 때 추가했던 로직이 header을 덮어 씌우고 있어서 수정했어요
dev서버에서 로그인, 로그아웃, 탈퇴 + access token 재발급 전부 다 잘되는 것 확인했습니다

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #350
